### PR TITLE
Add cryptographic wrapper APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+libs/mbedtls/*
+!libs/mbedtls/README.md
+libs/pqclean/*
+!libs/pqclean/README.md
+libaggregator.a
+*.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+MBEDTLS_DIR ?= libs/mbedtls
+PQCLEAN_DIR ?= libs/pqclean
+
+CFLAGS += -Iinclude -I$(MBEDTLS_DIR)/include \
+          -I$(PQCLEAN_DIR)/crypto_sign/mldsa-87/clean
+LDFLAGS += -L$(MBEDTLS_DIR)/library -lmbedtls -lmbedcrypto -lmbedx509
+
+SRC = src/aggregator.c
+OBJ = $(SRC:.c=.o)
+
+all: libaggregator.a
+
+libaggregator.a: $(OBJ)
+	ar rcs $@ $^
+
+clean:
+	rm -f $(OBJ) libaggregator.a
+
+.PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # encsigaggregator
+
+This project wraps several cryptographic algorithms with an abstract API.
+
+## Dependencies
+
+- [mbedtls](https://github.com/Mbed-TLS/mbedtls) tagged **v3.6.0**
+- [pqclean](https://github.com/pqclean/pqclean) commit **448c71a8**
+
+The sources for these libraries are expected inside `libs/mbedtls` and
+`libs/pqclean` respectively. Because this environment has no network access,
+you must obtain them manually. For example:
+
+```sh
+git clone --branch v3.6.0 https://github.com/Mbed-TLS/mbedtls.git libs/mbedtls
+cd libs/pqclean && git checkout 448c71a8
+```
+
+## Building
+
+Run `make` to build a static library `libaggregator.a`.
+The Makefile assumes the library paths above.
+
+## Usage
+
+The API defined in `include/aggregator.h` allows algorithm independent key
+generation, signing, verification and AES‑CBC‑256 encryption/decryption.

--- a/include/aggregator.h
+++ b/include/aggregator.h
@@ -1,0 +1,40 @@
+#ifndef AGGREGATOR_H
+#define AGGREGATOR_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    AGG_ALG_RSA4096,
+    AGG_ALG_LMS,
+    AGG_ALG_MLDSA87
+} agg_alg;
+
+typedef struct {
+    agg_alg alg;
+    void *key;
+    size_t key_len;
+} agg_key;
+
+int agg_keygen(agg_alg alg, agg_key *out_priv, agg_key *out_pub);
+int agg_sign(agg_alg alg, const agg_key *priv, const uint8_t *msg, size_t msg_len,
+             uint8_t *sig, size_t *sig_len);
+int agg_verify(agg_alg alg, const agg_key *pub, const uint8_t *msg, size_t msg_len,
+               const uint8_t *sig, size_t sig_len);
+
+int agg_encrypt_aes256cbc(const uint8_t key[32], const uint8_t iv[16],
+                          const uint8_t *in, size_t len, uint8_t *out);
+int agg_decrypt_aes256cbc(const uint8_t key[32], const uint8_t iv[16],
+                          const uint8_t *in, size_t len, uint8_t *out);
+
+void agg_free_key(agg_key *key);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AGGREGATOR_H */

--- a/libs/mbedtls/README.md
+++ b/libs/mbedtls/README.md
@@ -1,0 +1,1 @@
+Placeholder for mbedtls v3.6.0

--- a/libs/pqclean/README.md
+++ b/libs/pqclean/README.md
@@ -1,0 +1,1 @@
+Placeholder for pqclean commit 448c71a8

--- a/src/aggregator.c
+++ b/src/aggregator.c
@@ -1,0 +1,180 @@
+#include "aggregator.h"
+#include <stdlib.h>
+#include <string.h>
+
+#include <mbedtls/aes.h>
+#include <mbedtls/ctr_drbg.h>
+#include <mbedtls/entropy.h>
+#include <mbedtls/rsa.h>
+#include <mbedtls/md.h>
+#include <mbedtls/lms.h>
+
+#include "api.h" /* PQClean ml-dsa-87 */
+
+static int rng_callback(void *ctx, unsigned char *out, size_t len) {
+    return mbedtls_ctr_drbg_random((mbedtls_ctr_drbg_context *)ctx, out, len);
+}
+
+int agg_keygen(agg_alg alg, agg_key *out_priv, agg_key *out_pub) {
+    if (!out_priv || !out_pub)
+        return -1;
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context drbg;
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&drbg);
+    if (mbedtls_ctr_drbg_seed(&drbg, mbedtls_entropy_func, &entropy, NULL, 0) != 0)
+        return -1;
+
+    if (alg == AGG_ALG_RSA4096) {
+        mbedtls_rsa_context *rsa = calloc(1, sizeof(*rsa));
+        if (!rsa) return -1;
+        mbedtls_rsa_init(rsa, MBEDTLS_RSA_PKCS_V15, 0);
+        if (mbedtls_rsa_gen_key(rsa, rng_callback, &drbg, 4096, 65537) != 0) {
+            mbedtls_rsa_free(rsa);
+            free(rsa);
+            return -1;
+        }
+        out_priv->alg = out_pub->alg = AGG_ALG_RSA4096;
+        out_priv->key = rsa;
+        out_pub->key = rsa; /* RSA uses same context for priv/pub */
+        out_priv->key_len = out_pub->key_len = sizeof(*rsa);
+        return 0;
+    } else if (alg == AGG_ALG_LMS) {
+        mbedtls_lms_context *lms = calloc(1, sizeof(*lms));
+        if (!lms) return -1;
+        mbedtls_lms_init(lms);
+        if (mbedtls_lms_generate_keys(lms, rng_callback, &drbg) != 0) {
+            mbedtls_lms_free(lms);
+            free(lms);
+            return -1;
+        }
+        out_priv->alg = out_pub->alg = AGG_ALG_LMS;
+        out_priv->key = lms;
+        out_pub->key = lms; /* same context contains priv/pub */
+        out_priv->key_len = out_pub->key_len = sizeof(*lms);
+        return 0;
+    } else if (alg == AGG_ALG_MLDSA87) {
+        unsigned char *pk = NULL, *sk = NULL;
+        pk = malloc(PQCLEAN_MLDSA87_CLEAN_CRYPTO_PUBLICKEYBYTES);
+        sk = malloc(PQCLEAN_MLDSA87_CLEAN_CRYPTO_SECRETKEYBYTES);
+        if (!pk || !sk) {
+            free(pk); free(sk); return -1;
+        }
+        if (PQCLEAN_MLDSA87_CLEAN_crypto_sign_keypair(pk, sk) != 0) {
+            free(pk); free(sk); return -1;
+        }
+        out_pub->alg = out_priv->alg = AGG_ALG_MLDSA87;
+        out_pub->key = pk;
+        out_pub->key_len = PQCLEAN_MLDSA87_CLEAN_CRYPTO_PUBLICKEYBYTES;
+        out_priv->key = sk;
+        out_priv->key_len = PQCLEAN_MLDSA87_CLEAN_CRYPTO_SECRETKEYBYTES;
+        return 0;
+    }
+    return -1;
+}
+
+int agg_sign(agg_alg alg, const agg_key *priv, const uint8_t *msg, size_t msg_len,
+             uint8_t *sig, size_t *sig_len) {
+    if (!priv || !msg || !sig || !sig_len)
+        return -1;
+    if (alg != priv->alg)
+        return -1;
+    if (alg == AGG_ALG_RSA4096) {
+        mbedtls_rsa_context *rsa = priv->key;
+        if (mbedtls_rsa_pkcs1_sign(rsa, rng_callback, NULL,
+                                   MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA256,
+                                   0, msg, sig) != 0)
+            return -1;
+        *sig_len = mbedtls_rsa_get_len(rsa);
+        return 0;
+    } else if (alg == AGG_ALG_LMS) {
+        mbedtls_lms_context *lms = priv->key;
+        size_t olen = 0;
+        if (mbedtls_lms_sign(lms, msg, msg_len, sig, *sig_len, &olen,
+                              rng_callback, NULL) != 0)
+            return -1;
+        *sig_len = olen;
+        return 0;
+    } else if (alg == AGG_ALG_MLDSA87) {
+        if (PQCLEAN_MLDSA87_CLEAN_crypto_sign_signature(sig, sig_len,
+                                                         msg, msg_len,
+                                                         priv->key) != 0)
+            return -1;
+        return 0;
+    }
+    return -1;
+}
+
+int agg_verify(agg_alg alg, const agg_key *pub, const uint8_t *msg, size_t msg_len,
+               const uint8_t *sig, size_t sig_len) {
+    if (!pub || !msg || !sig)
+        return -1;
+    if (alg != pub->alg)
+        return -1;
+    if (alg == AGG_ALG_RSA4096) {
+        mbedtls_rsa_context *rsa = pub->key;
+        if (mbedtls_rsa_pkcs1_verify(rsa, NULL, NULL,
+                                     MBEDTLS_RSA_PUBLIC, MBEDTLS_MD_SHA256,
+                                     0, msg, sig) != 0)
+            return -1;
+        return 0;
+    } else if (alg == AGG_ALG_LMS) {
+        if (mbedtls_lms_verify(pub->key, msg, msg_len, sig, sig_len) != 0)
+            return -1;
+        return 0;
+    } else if (alg == AGG_ALG_MLDSA87) {
+        if (PQCLEAN_MLDSA87_CLEAN_crypto_sign_verify(sig, sig_len,
+                                                     msg, msg_len,
+                                                     pub->key) != 0)
+            return -1;
+        return 0;
+    }
+    return -1;
+}
+
+int agg_encrypt_aes256cbc(const uint8_t key[32], const uint8_t iv[16],
+                          const uint8_t *in, size_t len, uint8_t *out) {
+    if (!key || !iv || !in || !out)
+        return -1;
+    mbedtls_aes_context aes;
+    mbedtls_aes_init(&aes);
+    if (mbedtls_aes_setkey_enc(&aes, key, 256) != 0)
+        return -1;
+    unsigned char iv_copy[16];
+    memcpy(iv_copy, iv, 16);
+    if (mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_ENCRYPT, len, iv_copy, in, out) != 0)
+        return -1;
+    mbedtls_aes_free(&aes);
+    return 0;
+}
+
+int agg_decrypt_aes256cbc(const uint8_t key[32], const uint8_t iv[16],
+                          const uint8_t *in, size_t len, uint8_t *out) {
+    if (!key || !iv || !in || !out)
+        return -1;
+    mbedtls_aes_context aes;
+    mbedtls_aes_init(&aes);
+    if (mbedtls_aes_setkey_dec(&aes, key, 256) != 0)
+        return -1;
+    unsigned char iv_copy[16];
+    memcpy(iv_copy, iv, 16);
+    if (mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_DECRYPT, len, iv_copy, in, out) != 0)
+        return -1;
+    mbedtls_aes_free(&aes);
+    return 0;
+}
+
+void agg_free_key(agg_key *key) {
+    if (!key || !key->key) return;
+    if (key->alg == AGG_ALG_RSA4096) {
+        mbedtls_rsa_free((mbedtls_rsa_context *)key->key);
+        free(key->key);
+    } else if (key->alg == AGG_ALG_LMS) {
+        mbedtls_lms_free((mbedtls_lms_context *)key->key);
+        free(key->key);
+    } else if (key->alg == AGG_ALG_MLDSA87) {
+        free(key->key);
+    }
+    key->key = NULL;
+    key->key_len = 0;
+}


### PR DESCRIPTION
## Summary
- add abstract signing API with RSA, LMS and ML-DSA-87 support
- implement AES-CBC-256 encryption/decryption helpers
- provide Makefile for building a static library
- document required mbedtls and pqclean versions

## Testing
- `make` *(fails: mbedtls/aes.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683f9efc5a3c8332827dd49819211d4e