### PR TITLE
Setup dependencies for mbedtls 3.6.0 and pqclean 448c71a8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ MBEDTLS_DIR ?= libs/mbedtls
 PQCLEAN_DIR ?= libs/pqclean
 
 CFLAGS += -Iinclude -I$(MBEDTLS_DIR)/include \
-          -I$(PQCLEAN_DIR)/crypto_sign/mldsa-87/clean
+        -I$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean \
+        -DMBEDTLS_CONFIG_FILE='"mbedtls_custom_config.h"'
 LDFLAGS += -L$(MBEDTLS_DIR)/library -lmbedtls -lmbedcrypto -lmbedx509
 
 SRC = src/crypto.c

--- a/README.md
+++ b/README.md
@@ -8,8 +8,17 @@ This project wraps several cryptographic algorithms with an abstract API.
 - [pqclean](https://github.com/pqclean/pqclean) commit **448c71a8**
 
 The sources for these libraries are expected inside `libs/mbedtls` and
-`libs/pqclean` respectively. Because this environment has no network access,
-you must obtain them manually. For example:
+`libs/pqclean` respectively. A helper script is provided to fetch the
+correct versions automatically:
+
+```sh
+scripts/fetch_deps.sh
+```
+
+The provided `include/mbedtls_custom_config.h` enables all algorithms
+required by the project, including LMS private operations.
+
+If you prefer to fetch them manually, run:
 
 ```sh
 git clone --branch v3.6.0 https://github.com/Mbed-TLS/mbedtls.git libs/mbedtls
@@ -19,7 +28,8 @@ cd libs/pqclean && git checkout 448c71a8
 ## Building
 
 Run `make` to build a static library `libcrypto.a`.
-The Makefile assumes the library paths above.
+The Makefile assumes the library paths above and uses
+`include/mbedtls_custom_config.h` as the Mbed TLS configuration.
 
 ## Usage
 

--- a/include/mbedtls_custom_config.h
+++ b/include/mbedtls_custom_config.h
@@ -1,0 +1,15 @@
+#ifndef MBEDTLS_CUSTOM_CONFIG_H
+#define MBEDTLS_CUSTOM_CONFIG_H
+
+/*
+ * This configuration file enables the features used by encsigaggregator.
+ * It is based on the default Mbed TLS configuration for 3.6.0 with
+ * LMS private-key operations enabled.
+ */
+
+#include "mbedtls/mbedtls_config.h"
+
+/* enable LMS private key operations */
+#define MBEDTLS_LMS_PRIVATE
+
+#endif /* MBEDTLS_CUSTOM_CONFIG_H */

--- a/scripts/fetch_deps.sh
+++ b/scripts/fetch_deps.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+MBEDTLS_DIR="libs/mbedtls"
+PQCLEAN_DIR="libs/pqclean"
+
+# Clone mbedtls v3.6.0 if not present
+if [ ! -d "$MBEDTLS_DIR/.git" ]; then
+    rm -rf "$MBEDTLS_DIR"
+    git clone --branch v3.6.0 --depth 1 https://github.com/Mbed-TLS/mbedtls.git "$MBEDTLS_DIR"
+fi
+
+# Clone pqclean commit 448c71a8 if not present
+if [ ! -d "$PQCLEAN_DIR/.git" ]; then
+    rm -rf "$PQCLEAN_DIR"
+    git clone https://github.com/pqclean/pqclean.git "$PQCLEAN_DIR"
+    (cd "$PQCLEAN_DIR" && git checkout 448c71a8)
+fi

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -11,6 +11,11 @@
 
 #include "api.h" /* PQClean ml-dsa-87 */
 
+typedef struct {
+    mbedtls_lms_private_t priv;
+    mbedtls_lms_public_t pub;
+} lms_pair;
+
 static int rng_callback(void *ctx, unsigned char *out, size_t len) {
     return mbedtls_ctr_drbg_random((mbedtls_ctr_drbg_context *)ctx, out, len);
 }
@@ -28,7 +33,7 @@ int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub) {
     if (alg == CRYPTO_ALG_RSA4096) {
         mbedtls_rsa_context *rsa = calloc(1, sizeof(*rsa));
         if (!rsa) return -1;
-        mbedtls_rsa_init(rsa, MBEDTLS_RSA_PKCS_V15, 0);
+        mbedtls_rsa_init(rsa);
         if (mbedtls_rsa_gen_key(rsa, rng_callback, &drbg, 4096, 65537) != 0) {
             mbedtls_rsa_free(rsa);
             free(rsa);
@@ -40,18 +45,27 @@ int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub) {
         out_priv->key_len = out_pub->key_len = sizeof(*rsa);
         return 0;
     } else if (alg == CRYPTO_ALG_LMS) {
-        mbedtls_lms_context *lms = calloc(1, sizeof(*lms));
-        if (!lms) return -1;
-        mbedtls_lms_init(lms);
-        if (mbedtls_lms_generate_keys(lms, rng_callback, &drbg) != 0) {
-            mbedtls_lms_free(lms);
-            free(lms);
+        lms_pair *pair = calloc(1, sizeof(*pair));
+        if (!pair) return -1;
+        mbedtls_lms_private_init(&pair->priv);
+        mbedtls_lms_public_init(&pair->pub);
+        unsigned char seed[32];
+        if (mbedtls_ctr_drbg_random(&drbg, seed, sizeof(seed)) != 0 ||
+            mbedtls_lms_generate_private_key(&pair->priv,
+                                             MBEDTLS_LMS_SHA256_M32_H10,
+                                             MBEDTLS_LMOTS_SHA256_N32_W8,
+                                             rng_callback, &drbg,
+                                             seed, sizeof(seed)) != 0 ||
+            mbedtls_lms_calculate_public_key(&pair->pub, &pair->priv) != 0) {
+            mbedtls_lms_private_free(&pair->priv);
+            mbedtls_lms_public_free(&pair->pub);
+            free(pair);
             return -1;
         }
         out_priv->alg = out_pub->alg = CRYPTO_ALG_LMS;
-        out_priv->key = lms;
-        out_pub->key = lms; /* same context contains priv/pub */
-        out_priv->key_len = out_pub->key_len = sizeof(*lms);
+        out_priv->key = pair;
+        out_pub->key = pair; /* same struct contains priv/pub */
+        out_priv->key_len = out_pub->key_len = sizeof(*pair);
         return 0;
     } else if (alg == CRYPTO_ALG_MLDSA87) {
         unsigned char *pk = NULL, *sk = NULL;
@@ -79,27 +93,50 @@ int crypto_sign(crypto_alg alg, const crypto_key *priv, const uint8_t *msg, size
         return -1;
     if (alg != priv->alg)
         return -1;
+    mbedtls_entropy_context entropy;
+    mbedtls_ctr_drbg_context drbg;
+    mbedtls_entropy_init(&entropy);
+    mbedtls_ctr_drbg_init(&drbg);
+    if (mbedtls_ctr_drbg_seed(&drbg, mbedtls_entropy_func, &entropy, NULL, 0) != 0)
+        return -1;
     if (alg == CRYPTO_ALG_RSA4096) {
         mbedtls_rsa_context *rsa = priv->key;
-        if (mbedtls_rsa_pkcs1_sign(rsa, rng_callback, NULL,
-                                   MBEDTLS_RSA_PRIVATE, MBEDTLS_MD_SHA384,
-                                   0, msg, sig) != 0)
+        unsigned char hash[48];
+        if (mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA384),
+                       msg, msg_len, hash) != 0 ||
+            mbedtls_rsa_pkcs1_sign(rsa, rng_callback, &drbg,
+                                   MBEDTLS_MD_SHA384, 0, hash, sig) != 0) {
+            mbedtls_ctr_drbg_free(&drbg);
+            mbedtls_entropy_free(&entropy);
             return -1;
+        }
         *sig_len = mbedtls_rsa_get_len(rsa);
+        mbedtls_ctr_drbg_free(&drbg);
+        mbedtls_entropy_free(&entropy);
         return 0;
     } else if (alg == CRYPTO_ALG_LMS) {
-        mbedtls_lms_context *lms = priv->key;
+        lms_pair *pair = priv->key;
         size_t olen = 0;
-        if (mbedtls_lms_sign(lms, msg, msg_len, sig, *sig_len, &olen,
-                              rng_callback, NULL) != 0)
+        if (mbedtls_lms_sign(&pair->priv, rng_callback, &drbg,
+                              msg, msg_len, sig, *sig_len, &olen) != 0) {
+            mbedtls_ctr_drbg_free(&drbg);
+            mbedtls_entropy_free(&entropy);
             return -1;
+        }
         *sig_len = olen;
+        mbedtls_ctr_drbg_free(&drbg);
+        mbedtls_entropy_free(&entropy);
         return 0;
     } else if (alg == CRYPTO_ALG_MLDSA87) {
         if (PQCLEAN_MLDSA87_CLEAN_crypto_sign_signature(sig, sig_len,
                                                          msg, msg_len,
-                                                         priv->key) != 0)
+                                                         priv->key) != 0) {
+            mbedtls_ctr_drbg_free(&drbg);
+            mbedtls_entropy_free(&entropy);
             return -1;
+        }
+        mbedtls_ctr_drbg_free(&drbg);
+        mbedtls_entropy_free(&entropy);
         return 0;
     }
     return -1;
@@ -111,15 +148,18 @@ int crypto_verify(crypto_alg alg, const crypto_key *pub, const uint8_t *msg, siz
         return -1;
     if (alg != pub->alg)
         return -1;
+    unsigned char hash[48];
     if (alg == CRYPTO_ALG_RSA4096) {
         mbedtls_rsa_context *rsa = pub->key;
-        if (mbedtls_rsa_pkcs1_verify(rsa, NULL, NULL,
-                                     MBEDTLS_RSA_PUBLIC, MBEDTLS_MD_SHA384,
-                                     0, msg, sig) != 0)
+        if (mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA384),
+                       msg, msg_len, hash) != 0 ||
+            mbedtls_rsa_pkcs1_verify(rsa, MBEDTLS_MD_SHA384, 0,
+                                     hash, sig) != 0)
             return -1;
         return 0;
     } else if (alg == CRYPTO_ALG_LMS) {
-        if (mbedtls_lms_verify(pub->key, msg, msg_len, sig, sig_len) != 0)
+        lms_pair *pair = pub->key;
+        if (mbedtls_lms_verify(&pair->pub, msg, msg_len, sig, sig_len) != 0)
             return -1;
         return 0;
     } else if (alg == CRYPTO_ALG_MLDSA87) {
@@ -170,8 +210,10 @@ void crypto_free_key(crypto_key *key) {
         mbedtls_rsa_free((mbedtls_rsa_context *)key->key);
         free(key->key);
     } else if (key->alg == CRYPTO_ALG_LMS) {
-        mbedtls_lms_free((mbedtls_lms_context *)key->key);
-        free(key->key);
+        lms_pair *pair = key->key;
+        mbedtls_lms_private_free(&pair->priv);
+        mbedtls_lms_public_free(&pair->pub);
+        free(pair);
     } else if (key->alg == CRYPTO_ALG_MLDSA87) {
         free(key->key);
     }


### PR DESCRIPTION
## Summary
- add `fetch_deps.sh` script for grabbing mbedtls 3.6.0 and pqclean 448c71a8
- document how to fetch deps via script
- add custom Mbed TLS config enabling LMS priv ops
- update Makefile to use config and remove MBEDTLS_LMS_PRIVATE flag
- update crypto implementation to build with mbedtls 3.6.0 APIs

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_683fa3f987b08332882075d3bf4a1ce1