### PR TITLE
Implement SHA-384 helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,17 @@ PQCLEAN_DIR ?= libs/pqclean
 
 CFLAGS += -Iinclude -I$(MBEDTLS_DIR)/include \
         -I$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean \
+        -I$(PQCLEAN_DIR)/common \
         -DMBEDTLS_CONFIG_FILE='"mbedtls_custom_config.h"'
 LDFLAGS += -L$(MBEDTLS_DIR)/library -lmbedtls -lmbedcrypto -lmbedx509 \
            -L$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean -lml-dsa-87_clean
 
-SRC = src/crypto.c
+SRC = src/crypto.c \
+       $(PQCLEAN_DIR)/common/randombytes.c \
+       $(PQCLEAN_DIR)/common/fips202.c \
+       $(PQCLEAN_DIR)/common/sha2.c \
+       $(PQCLEAN_DIR)/common/nistseedexpander.c \
+       $(PQCLEAN_DIR)/common/sp800-185.c
 OBJ = $(SRC:.c=.o)
 TOOL_SRC = src/main.c src/cliopts.c
 TOOL_OBJ = $(TOOL_SRC:.c=.o)

--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ The Makefile assumes the library paths above and uses
 The API defined in `include/crypto.h` allows algorithm independent key
 generation, signing, verification and AES‑CBC encryption/decryption with
 128/192/256‑bit keys.
+It also exposes a helper to compute SHA‑384 digests of arbitrary data.

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -37,6 +37,8 @@ int crypto_decrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t iv[16],
                           const uint8_t *in, size_t len, uint8_t *out);
 
+int crypto_sha384(const uint8_t *in, size_t len, uint8_t out[48]);
+
 void crypto_free_key(crypto_key *key);
 
 #ifdef __cplusplus

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -338,6 +338,13 @@ int crypto_decrypt_aescbc(const uint8_t *key, size_t bits,
     return 0;
 }
 
+int crypto_sha384(const uint8_t *in, size_t len, uint8_t out[48]) {
+    if (!in || !out)
+        return -1;
+    return mbedtls_md(mbedtls_md_info_from_type(MBEDTLS_MD_SHA384),
+                      in, len, out);
+}
+
 void crypto_free_key(crypto_key *key) {
     if (!key || !key->key) return;
     if (key->alg == CRYPTO_ALG_RSA4096) {


### PR DESCRIPTION
## Summary
- expose crypto_sha384 API
- provide implementation using mbedtls
- compile PQClean common sources for needed hashing functions
- document the new helper in the README

## Testing
- `make -C libs/mbedtls lib`
- `make -C libs/pqclean/crypto_sign/ml-dsa-87/clean`
- `make` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_6840019026708332b3c78802e30e8a81