### PR TITLE
Ensure build instructions cover dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,9 @@ Coding Guidelines and Build Steps
   crypto.c helper functions.
 - Before building the project, make sure the dependencies are fetched and built:
   1. Run `scripts/fetch_deps.sh` to clone Mbed TLS and PQClean.
-  2. Build Mbed TLS with `make -C libs/mbedtls library`.
-  3. Build PQClean's ML‑DSA‑87 with `make -C libs/pqclean/crypto_sign/ml-dsa-87/clean`.
+  2. Run `git submodule update --init` inside `libs/mbedtls` to fetch its framework submodule.
+  3. Install the Python packages `jsonschema` and `jinja2` as they are required for the Mbed TLS build (e.g. `pip install jsonschema jinja2`).
+  4. Build Mbed TLS with `make -C libs/mbedtls lib`.
+  5. Build PQClean's ML‑DSA‑87 with `make -C libs/pqclean/crypto_sign/ml-dsa-87/clean`.
 - The top level `make` depends on the libraries above to compile `libcrypto.a`
   and the example tool `encsigtool`.


### PR DESCRIPTION
## Summary
- document submodule step, Python deps and correct make command in `AGENTS.md`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6840352659ac83329f1f089a728104b7