### PR TITLE
Ensure dependencies build before all and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,10 @@ clean:
 encsigtool: libcrypto.a $(TOOL_OBJ)
 	$(CC) $(CFLAGS) -o $@ $(TOOL_OBJ) -Wl,--start-group libcrypto.a $(LDFLAGS) -Wl,--end-group
 
-$(TEST_BIN): libcrypto.a $(TEST_OBJ)
+$(TEST_BIN): $(MBEDTLS_LIBS) $(PQ_LIB) libcrypto.a $(TEST_OBJ)
 	$(CC) $(CFLAGS) -o $@ $(TEST_OBJ) -Wl,--start-group libcrypto.a $(LDFLAGS) -Wl,--end-group -lcmocka
 
-test: $(TEST_BIN)
+test: $(MBEDTLS_LIBS) $(PQ_LIB) $(TEST_BIN)
 	$(TEST_BIN)
 
 .PHONY: all clean test

--- a/scripts/fetch_deps.sh
+++ b/scripts/fetch_deps.sh
@@ -8,6 +8,7 @@ PQCLEAN_DIR="libs/pqclean"
 if [ ! -d "$MBEDTLS_DIR/.git" ]; then
     rm -rf "$MBEDTLS_DIR"
     git clone --branch v3.6.0 --depth 1 https://github.com/Mbed-TLS/mbedtls.git "$MBEDTLS_DIR"
+    (cd "$MBEDTLS_DIR" && git submodule update --init)
 fi
 
 # Clone pqclean commit 448c71a8 if not present


### PR DESCRIPTION
## Summary
- build dependencies when running `make test`
- update `fetch_deps.sh` to initialize Mbed TLS submodules

## Testing
- `scripts/fetch_deps.sh`
- `make -C libs/mbedtls lib`
- `make -C libs/pqclean/crypto_sign/ml-dsa-87/clean`
- `make` *(fails: undefined reference to `mbedtls_lms_private_init`)*
- `make test` *(fails: cmocka.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68428885d3948332ab86c0c793810de2