### PR TITLE
Add -std=c99 to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,8 @@ PQCLEAN_DIR ?= libs/pqclean
 CFLAGS += -Iinclude -I$(MBEDTLS_DIR)/include \
         -I$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean \
         -I$(PQCLEAN_DIR)/common \
-       -DMBEDTLS_CONFIG_FILE='"mbedtls_custom_config.h"'
-
-CFLAGS += -std=c99
+        -DMBEDTLS_CONFIG_FILE='"mbedtls_custom_config.h"' \
+        -std=c99
 LDFLAGS += -L$(MBEDTLS_DIR)/library -lmbedtls -lmbedcrypto -lmbedx509 \
            -L$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean -lml-dsa-87_clean
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ PQCLEAN_DIR ?= libs/pqclean
 CFLAGS += -Iinclude -I$(MBEDTLS_DIR)/include \
         -I$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean \
         -I$(PQCLEAN_DIR)/common \
-        -DMBEDTLS_CONFIG_FILE='"mbedtls_custom_config.h"'
+       -DMBEDTLS_CONFIG_FILE='"mbedtls_custom_config.h"'
+
+CFLAGS += -std=c99
 LDFLAGS += -L$(MBEDTLS_DIR)/library -lmbedtls -lmbedcrypto -lmbedx509 \
            -L$(PQCLEAN_DIR)/crypto_sign/ml-dsa-87/clean -lml-dsa-87_clean
 


### PR DESCRIPTION
## Summary
- ensure all sources use the C99 standard

## Testing
- `make -n src/main.o`
- `make -n encsigtool`
- `make -n test` *(fails: No rule to make target 'library')*

------
https://chatgpt.com/codex/tasks/task_e_6847da3c866483329fe9167663404224