### PR TITLE
Update manual library build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ git clone --branch v3.6.0 https://github.com/Mbed-TLS/mbedtls.git libs/mbedtls
 cd libs/pqclean && git checkout 448c71a8
 ```
 
+After cloning, fetch the Mbed TLS submodule, install the required Python
+packages and build both libraries:
+
+```sh
+git -C libs/mbedtls submodule update --init
+pip install jsonschema jinja2
+make -C libs/mbedtls lib
+make -C libs/pqclean/crypto_sign/ml-dsa-87/clean
+```
+
 ## Building
 
 Run `make` to build a static library `libcrypto.a`.


### PR DESCRIPTION
## Summary
- document initializing Mbed TLS submodule
- mention Python packages required for building
- add commands to build both libraries

## Testing
- `git -C libs/mbedtls submodule update --init`
- `pip install jsonschema jinja2`
- `make -C libs/mbedtls lib`
- `make -C libs/pqclean/crypto_sign/ml-dsa-87/clean`


------
https://chatgpt.com/codex/tasks/task_e_6847da6b76708332a909f6b05709e026