### PR TITLE
Define crypto constants

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -8,6 +8,24 @@
 extern "C" {
 #endif
 
+/* Algorithm related constants */
+#define CRYPTO_AES_KEY_BITS_128 128
+#define CRYPTO_AES_KEY_BITS_192 192
+#define CRYPTO_AES_KEY_BITS_256 256
+
+#define CRYPTO_AES_IV_SIZE 16
+#define CRYPTO_AES_MAX_KEY_SIZE 32
+
+#define CRYPTO_RSA_BITS 4096
+#define CRYPTO_RSA_EXPONENT 65537
+#define CRYPTO_RSA_SIG_SIZE (CRYPTO_RSA_BITS / 8)
+
+#define CRYPTO_SHA384_DIGEST_SIZE 48
+
+#define CRYPTO_LMS_SEED_SIZE 32
+
+#define CRYPTO_MAX_SIG_SIZE 10240
+
 typedef enum {
     CRYPTO_ALG_RSA4096,
     CRYPTO_ALG_LMS,
@@ -24,20 +42,21 @@ int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub);
 int crypto_load_keypair(crypto_alg alg, const char *priv_path, const char *pub_path,
                         crypto_key *out_priv, crypto_key *out_pub);
 int crypto_init_aes(size_t bits, const char *key_path, const char *iv_path,
-                    uint8_t *key_out, uint8_t iv_out[16]);
+                    uint8_t *key_out, uint8_t iv_out[CRYPTO_AES_IV_SIZE]);
 int crypto_sign(crypto_alg alg, const crypto_key *priv, const uint8_t *msg, size_t msg_len,
                 uint8_t *sig, size_t *sig_len);
 int crypto_verify(crypto_alg alg, const crypto_key *pub, const uint8_t *msg, size_t msg_len,
                   const uint8_t *sig, size_t sig_len);
 
 int crypto_encrypt_aescbc(const uint8_t *key, size_t bits,
-                          const uint8_t iv[16],
+                          const uint8_t iv[CRYPTO_AES_IV_SIZE],
                           const uint8_t *in, size_t len, uint8_t *out);
 int crypto_decrypt_aescbc(const uint8_t *key, size_t bits,
-                          const uint8_t iv[16],
+                          const uint8_t iv[CRYPTO_AES_IV_SIZE],
                           const uint8_t *in, size_t len, uint8_t *out);
 
-int crypto_sha384(const uint8_t *in, size_t len, uint8_t out[48]);
+int crypto_sha384(const uint8_t *in, size_t len,
+                  uint8_t out[CRYPTO_SHA384_DIGEST_SIZE]);
 
 void crypto_free_key(crypto_key *key);
 

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -8,22 +8,29 @@
 extern "C" {
 #endif
 
-/* Algorithm related constants */
+/* AES key sizes in bits */
 #define CRYPTO_AES_KEY_BITS_128 128
 #define CRYPTO_AES_KEY_BITS_192 192
 #define CRYPTO_AES_KEY_BITS_256 256
 
+/* Size of the CBC initialization vector in bytes */
 #define CRYPTO_AES_IV_SIZE 16
+/* Maximum AES key size in bytes (AES-256) */
 #define CRYPTO_AES_MAX_KEY_SIZE 32
 
-#define CRYPTO_RSA_BITS 4096
-#define CRYPTO_RSA_EXPONENT 65537
+/* Parameters for RSA4096 key generation */
+#define CRYPTO_RSA_BITS 4096       /* modulus size in bits */
+#define CRYPTO_RSA_EXPONENT 65537  /* public exponent */
+/* RSA signature size in bytes for a 4096-bit key */
 #define CRYPTO_RSA_SIG_SIZE (CRYPTO_RSA_BITS / 8)
 
+/* Output size of SHA-384 in bytes */
 #define CRYPTO_SHA384_DIGEST_SIZE 48
 
+/* Length of the random seed used to generate LMS keys */
 #define CRYPTO_LMS_SEED_SIZE 32
 
+/* Buffer large enough to hold any supported signature */
 #define CRYPTO_MAX_SIG_SIZE 10240
 
 typedef enum {

--- a/src/cliopts.c
+++ b/src/cliopts.c
@@ -24,7 +24,7 @@ int cli_parse_args(int argc, char **argv, cli_options *o)
     if (!o) return -1;
     optind = 1;
     o->alg = CRYPTO_ALG_RSA4096;
-    o->aes_bits = 256;
+    o->aes_bits = CRYPTO_AES_KEY_BITS_256;
     o->infile = o->outfile = NULL;
     o->pk_path = o->sk_path = NULL;
     o->aes_key_path = o->aes_iv_path = NULL;
@@ -54,7 +54,9 @@ int cli_parse_args(int argc, char **argv, cli_options *o)
             break;
         case 'b':
             o->aes_bits = (size_t)atoi(optarg);
-            if (o->aes_bits != 128 && o->aes_bits != 192 && o->aes_bits != 256) {
+            if (o->aes_bits != CRYPTO_AES_KEY_BITS_128 &&
+                o->aes_bits != CRYPTO_AES_KEY_BITS_192 &&
+                o->aes_bits != CRYPTO_AES_KEY_BITS_256) {
                 fprintf(stderr, "Invalid AES bits\n");
                 return -1;
             }

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -38,7 +38,7 @@ void test_cli_valid_minimal(void **state) {
     cli_options opts;
     assert_int_equal(cli_parse_args(5, argv, &opts), 0);
     assert_int_equal(opts.alg, CRYPTO_ALG_RSA4096);
-    assert_int_equal(opts.aes_bits, 256);
+    assert_int_equal(opts.aes_bits, CRYPTO_AES_KEY_BITS_256);
     assert_string_equal(opts.infile, "in");
     assert_string_equal(opts.outfile, "out");
 }

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -9,9 +9,9 @@
 
 static void test_sha384(void **state) {
     (void)state;
-    uint8_t out[48];
+    uint8_t out[CRYPTO_SHA384_DIGEST_SIZE];
     assert_int_equal(crypto_sha384((const uint8_t *)"abc", 3, out), 0);
-    const uint8_t expected[48] = {
+    const uint8_t expected[CRYPTO_SHA384_DIGEST_SIZE] = {
         0xcb,0x00,0x75,0x3f,0x45,0xa3,0x5e,0x8b,
         0xb5,0xa0,0x3d,0x69,0x9a,0xc6,0x50,0x07,
         0x27,0x2c,0x32,0xab,0x0e,0xde,0xd1,0x63,
@@ -19,21 +19,21 @@ static void test_sha384(void **state) {
         0x80,0x86,0x07,0x2b,0xa1,0xe7,0xcc,0x23,
         0x58,0xba,0xec,0xa1,0x34,0xc8,0x25,0xa7
     };
-    assert_memory_equal(out, expected, 48);
+    assert_memory_equal(out, expected, CRYPTO_SHA384_DIGEST_SIZE);
 }
 
 static void test_aes_cbc(void **state) {
     (void)state;
-    uint8_t key[32];
-    uint8_t iv[16];
-    assert_int_equal(crypto_init_aes(256, NULL, NULL, key, iv), 0);
+    uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
+    uint8_t iv[CRYPTO_AES_IV_SIZE];
+    assert_int_equal(crypto_init_aes(CRYPTO_AES_KEY_BITS_256, NULL, NULL, key, iv), 0);
 
     const uint8_t plaintext[32] =
         "0123456789abcdef0123456789abcdef";
     uint8_t enc[32];
     uint8_t dec[32];
-    assert_int_equal(crypto_encrypt_aescbc(key, 256, iv, plaintext, 32, enc), 0);
-    assert_int_equal(crypto_decrypt_aescbc(key, 256, iv, enc, 32, dec), 0);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv, plaintext, 32, enc), 0);
+    assert_int_equal(crypto_decrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv, enc, 32, dec), 0);
     assert_memory_equal(dec, plaintext, 32);
 }
 
@@ -47,7 +47,7 @@ static void test_rsa_sign_verify(void **state) {
     assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096, &priv,
                                  msg, sizeof(msg) - 1,
                                  sig, &sig_len), 0);
-    assert_int_equal(sig_len, 512);
+    assert_int_equal(sig_len, CRYPTO_RSA_SIG_SIZE);
     assert_true(sig_len < sizeof(sig));
     assert_int_equal(crypto_verify(CRYPTO_ALG_RSA4096, &pub,
                                    msg, sizeof(msg) - 1,
@@ -101,30 +101,30 @@ static void test_mldsa_sign_verify(void **state) {
 
 static void test_crypto_init_aes_invalid(void **state) {
     (void)state;
-    uint8_t key[32];
-    uint8_t iv[16];
+    uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
+    uint8_t iv[CRYPTO_AES_IV_SIZE];
     assert_int_equal(crypto_init_aes(100, NULL, NULL, key, iv), -1);
-    assert_int_equal(crypto_init_aes(128, NULL, NULL, NULL, iv), -1);
-    assert_int_equal(crypto_init_aes(128, NULL, NULL, key, NULL), -1);
+    assert_int_equal(crypto_init_aes(CRYPTO_AES_KEY_BITS_128, NULL, NULL, NULL, iv), -1);
+    assert_int_equal(crypto_init_aes(CRYPTO_AES_KEY_BITS_128, NULL, NULL, key, NULL), -1);
 }
 
 static void test_crypto_sha384_invalid(void **state) {
     (void)state;
-    uint8_t out[48];
+    uint8_t out[CRYPTO_SHA384_DIGEST_SIZE];
     assert_int_equal(crypto_sha384(NULL, 0, out), -1);
     assert_int_equal(crypto_sha384((const uint8_t *)"a", 1, NULL), -1);
 }
 
 static void test_crypto_encrypt_invalid(void **state) {
     (void)state;
-    uint8_t key[16] = {0};
-    uint8_t iv[16] = {0};
-    uint8_t in[16] = {0};
-    uint8_t out[16];
-    assert_int_equal(crypto_encrypt_aescbc(NULL, 128, iv, in, 16, out), -1);
-    assert_int_equal(crypto_encrypt_aescbc(key, 128, NULL, in, 16, out), -1);
-    assert_int_equal(crypto_encrypt_aescbc(key, 128, iv, NULL, 16, out), -1);
-    assert_int_equal(crypto_encrypt_aescbc(key, 128, iv, in, 16, NULL), -1);
+    uint8_t key[CRYPTO_AES_IV_SIZE] = {0};
+    uint8_t iv[CRYPTO_AES_IV_SIZE] = {0};
+    uint8_t in[CRYPTO_AES_IV_SIZE] = {0};
+    uint8_t out[CRYPTO_AES_IV_SIZE];
+    assert_int_equal(crypto_encrypt_aescbc(NULL, CRYPTO_AES_KEY_BITS_128, iv, in, CRYPTO_AES_IV_SIZE, out), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, NULL, in, CRYPTO_AES_IV_SIZE, out), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv, NULL, CRYPTO_AES_IV_SIZE, out), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv, in, CRYPTO_AES_IV_SIZE, NULL), -1);
 }
 
 static void test_crypto_sign_invalid(void **state) {

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -42,7 +42,8 @@ static void test_rsa_sign_verify(void **state) {
     crypto_key priv = {0}, pub = {0};
     assert_int_equal(crypto_keygen(CRYPTO_ALG_RSA4096, &priv, &pub), 0);
     const uint8_t msg[] = "test message";
-    uint8_t sig[1024];
+    /* large enough to hold the RSA signature */
+    uint8_t sig[CRYPTO_MAX_SIG_SIZE];
     size_t sig_len = 0; /* crypto_sign should update this */
     assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096, &priv,
                                  msg, sizeof(msg) - 1,


### PR DESCRIPTION
## Summary
- add macros for crypto sizes and parameters in `crypto.h`
- replace numeric constants throughout code with named macros

## Testing
- `make test` *(fails: No rule to make target 'library')*

------
https://chatgpt.com/codex/tasks/task_e_684a7b9492308332b643da6a311bca86