### PR TITLE
build: automate third-party setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,9 @@ Coding Guidelines and Build Steps
      python3 python3-pip`.
   2. Install the Python packages `jsonschema` and `jinja2` required by Mbed TLS
      (e.g. `pip3 install jsonschema jinja2`).
-  3. Run `scripts/fetch_deps.sh` to clone Mbed TLS and PQClean.
-  4. Run `git submodule update --init` inside `libs/mbedtls` to fetch its framework submodule.
-  5. Build Mbed TLS with `make -C libs/mbedtls lib`.
-  6. Build PQClean's ML‑DSA‑87 with `make -C libs/pqclean/crypto_sign/ml-dsa-87/clean`.
+  3. Run `scripts/install_third_party.sh` to clone Mbed TLS and PQClean and
+     build their libraries. Mbed TLS is compiled with
+     `include/mbedtls_custom_config.h` to enable LMS support.
 - Install the cmocka development package (e.g. `sudo apt-get install libcmocka-dev`) to compile the unit tests.
 - The top level `make` depends on the libraries above to compile `libcrypto.a`
   and the example tool `encsigtool`.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This project wraps several cryptographic algorithms with an abstract API.
 - [pqclean](https://github.com/pqclean/pqclean) commit **448c71a8**
 
 The sources for these libraries are expected inside `libs/mbedtls` and
-`libs/pqclean` respectively. A helper script is provided to fetch the
-correct versions automatically:
+`libs/pqclean` respectively. A helper script is provided to fetch and build
+the correct versions automatically:
 
 ```sh
-scripts/fetch_deps.sh
+scripts/install_third_party.sh
 ```
 
 The provided `include/mbedtls_custom_config.h` enables all algorithms
@@ -31,7 +31,8 @@ packages and build both libraries:
 ```sh
 git -C libs/mbedtls submodule update --init
 pip install jsonschema jinja2
-make -C libs/mbedtls lib
+cp include/mbedtls_custom_config.h libs/mbedtls/include/mbedtls
+make -C libs/mbedtls lib CFLAGS="-O2 -DMBEDTLS_CONFIG_FILE='\"mbedtls/mbedtls_custom_config.h\"'"
 make -C libs/pqclean/crypto_sign/ml-dsa-87/clean
 ```
 

--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 set -e
 
-MBEDTLS_DIR="libs/mbedtls"
-PQCLEAN_DIR="libs/pqclean"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+MBEDTLS_DIR="$ROOT_DIR/libs/mbedtls"
+PQCLEAN_DIR="$ROOT_DIR/libs/pqclean"
+CONFIG_FILE="$ROOT_DIR/include/mbedtls_custom_config.h"
 
 # Clone mbedtls v3.6.0 if not present
 if [ ! -d "$MBEDTLS_DIR/.git" ]; then
@@ -11,9 +14,16 @@ if [ ! -d "$MBEDTLS_DIR/.git" ]; then
     (cd "$MBEDTLS_DIR" && git submodule update --init)
 fi
 
+# Build mbedtls with the custom configuration
+cp "$CONFIG_FILE" "$MBEDTLS_DIR/include/mbedtls"
+make -C "$MBEDTLS_DIR" lib CFLAGS="-O2 -DMBEDTLS_CONFIG_FILE='\"mbedtls/mbedtls_custom_config.h\"'"
+
 # Clone pqclean commit 448c71a8 if not present
 if [ ! -d "$PQCLEAN_DIR/.git" ]; then
     rm -rf "$PQCLEAN_DIR"
     git clone https://github.com/pqclean/pqclean.git "$PQCLEAN_DIR"
     (cd "$PQCLEAN_DIR" && git checkout 448c71a8)
 fi
+
+# Build PQClean's ML-DSA-87 implementation
+make -C "$PQCLEAN_DIR/crypto_sign/ml-dsa-87/clean"


### PR DESCRIPTION
## Summary
- replace `fetch_deps.sh` with `install_third_party.sh` that clones and builds Mbed TLS and PQClean using the project's custom Mbed TLS configuration
- document the new script and custom configuration steps in README and AGENTS
- copy the custom Mbed TLS configuration into the library without renaming its filename
- compile Mbed TLS with the custom config by passing `MBEDTLS_CONFIG_FILE` via `CFLAGS`

## Testing
- `scripts/install_third_party.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689ae7adfd9c8332b97560b8098752bf