### PR TITLE
Add debug build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,4 +50,7 @@ $(TEST_BIN): $(MBEDTLS_LIBS) $(PQ_LIB) libcrypto.a $(TEST_OBJ)
 test: $(MBEDTLS_LIBS) $(PQ_LIB) $(TEST_BIN)
 	$(TEST_BIN)
 
-.PHONY: all clean test
+debug: CFLAGS += -g -O0
+debug: clean encsigtool
+
+.PHONY: all clean test debug

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Run `make` to build a static library `libcrypto.a`.
 The Makefile assumes the library paths above and uses
 `include/mbedtls_custom_config.h` as the Mbed TLS configuration.
 
+For a debug build of the example tool, invoke `make debug`.
+
 ## Running Tests
 
 Unit tests are written with [CMocka](https://cmocka.org). Install the


### PR DESCRIPTION
## Summary
- add `debug` make target to build encsigtool with `-g -O0`
- document debug build instructions in README

## Testing
- `make debug`
- `file encsigtool`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cf5f83ec833296b203ee4b613388