### PR TITLE
Avoid extra block when AES-CBC input is block aligned

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -60,10 +60,12 @@ int crypto_verify(crypto_alg alg, const crypto_key *pub, const uint8_t *msg, siz
 
 int crypto_encrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t iv[CRYPTO_AES_IV_SIZE],
-                          const uint8_t *in, size_t len, uint8_t *out);
+                          const uint8_t *in, size_t len, uint8_t *out,
+                          size_t *out_len);
 int crypto_decrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t iv[CRYPTO_AES_IV_SIZE],
-                          const uint8_t *in, size_t len, uint8_t *out);
+                          const uint8_t *in, size_t len, uint8_t *out,
+                          size_t *out_len);
 
 int crypto_sha384(const uint8_t *in, size_t len,
                   uint8_t out[CRYPTO_SHA384_DIGEST_SIZE]);

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -404,43 +404,80 @@ static int aes_setkey(mbedtls_aes_context *aes, const uint8_t *key, size_t bits,
 
 int crypto_encrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t iv[CRYPTO_AES_IV_SIZE],
-                          const uint8_t *in, size_t len, uint8_t *out) {
-    if (!key || !iv || !in || !out)
+                          const uint8_t *in, size_t len, uint8_t *out,
+                          size_t *out_len) {
+    if (!key || !iv || !in || !out || !out_len)
         return -1;
+    size_t padded_len =
+        ((len + CRYPTO_AES_IV_SIZE - 1) / CRYPTO_AES_IV_SIZE) * CRYPTO_AES_IV_SIZE;
+    unsigned char *buf = calloc(1, padded_len);
+    if (!buf)
+        return -1;
+    memcpy(buf, in, len);
+    unsigned char pad = (unsigned char)(padded_len - len);
+    if (pad)
+        memset(buf + len, pad, pad);
     mbedtls_aes_context aes;
     mbedtls_aes_init(&aes);
     if (aes_setkey(&aes, key, bits, 1) != 0) {
+        free(buf);
         mbedtls_aes_free(&aes);
         return -1;
     }
     unsigned char iv_copy[CRYPTO_AES_IV_SIZE];
     memcpy(iv_copy, iv, CRYPTO_AES_IV_SIZE);
-    if (mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_ENCRYPT, len, iv_copy, in, out) != 0) {
+    if (mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_ENCRYPT, padded_len, iv_copy, buf, out) != 0) {
+        free(buf);
         mbedtls_aes_free(&aes);
         return -1;
     }
     mbedtls_aes_free(&aes);
+    free(buf);
+    *out_len = padded_len;
     return 0;
 }
 
 int crypto_decrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t iv[CRYPTO_AES_IV_SIZE],
-                          const uint8_t *in, size_t len, uint8_t *out) {
-    if (!key || !iv || !in || !out)
+                          const uint8_t *in, size_t len, uint8_t *out,
+                          size_t *out_len) {
+    if (!key || !iv || !in || !out || !out_len ||
+        (len % CRYPTO_AES_IV_SIZE) != 0)
+        return -1;
+    unsigned char *buf = malloc(len);
+    if (!buf)
         return -1;
     mbedtls_aes_context aes;
     mbedtls_aes_init(&aes);
     if (aes_setkey(&aes, key, bits, 0) != 0) {
+        free(buf);
         mbedtls_aes_free(&aes);
         return -1;
     }
     unsigned char iv_copy[CRYPTO_AES_IV_SIZE];
     memcpy(iv_copy, iv, CRYPTO_AES_IV_SIZE);
-    if (mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_DECRYPT, len, iv_copy, in, out) != 0) {
+    if (mbedtls_aes_crypt_cbc(&aes, MBEDTLS_AES_DECRYPT, len, iv_copy, in, buf) != 0) {
+        free(buf);
         mbedtls_aes_free(&aes);
         return -1;
     }
     mbedtls_aes_free(&aes);
+    unsigned char pad = buf[len - 1];
+    size_t plen = len;
+    if (pad > 0 && pad <= CRYPTO_AES_IV_SIZE) {
+        int valid = 1;
+        for (size_t i = 0; i < pad; ++i) {
+            if (buf[len - 1 - i] != pad) {
+                valid = 0;
+                break;
+            }
+        }
+        if (valid)
+            plen -= pad;
+    }
+    memcpy(out, buf, plen);
+    free(buf);
+    *out_len = plen;
     return 0;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -81,15 +81,18 @@ int main(int argc, char **argv) {
         free(buf); free(sig); crypto_free_key(&priv); return 1; }
 
     /* Encrypt the input */
-    uint8_t *enc = malloc(fsize);
+    size_t enc_len =
+        ((fsize + CRYPTO_AES_IV_SIZE - 1) / CRYPTO_AES_IV_SIZE) * CRYPTO_AES_IV_SIZE;
+    uint8_t *enc = malloc(enc_len);
     if (!enc) { free(buf); free(sig); crypto_free_key(&priv); return 1; }
-    if (crypto_encrypt_aescbc(aes_key, opts.aes_bits, iv, buf, fsize, enc) != 0) {
+    if (crypto_encrypt_aescbc(aes_key, opts.aes_bits, iv, buf, fsize, enc,
+                              &enc_len) != 0) {
         fprintf(stderr, "Encryption failed\n");
         free(buf); free(sig); free(enc); crypto_free_key(&priv); return 1; }
 
     /* Write everything to the requested output */
     if (write_output(opts.outfile, generate, &priv, &pub, opts.aes_bits,
-                     aes_key, iv, sig, sig_len, enc, fsize) != 0) {
+                     aes_key, iv, sig, sig_len, enc, enc_len) != 0) {
         fprintf(stderr, "Write failed\n");
         free(buf); free(sig); free(enc); crypto_free_key(&priv); return 1;
     }

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -31,10 +31,37 @@ static void test_aes_cbc(void **state) {
     const uint8_t plaintext[32] =
         "0123456789abcdef0123456789abcdef";
     uint8_t enc[32];
+    size_t enc_len = 0;
     uint8_t dec[32];
-    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv, plaintext, 32, enc), 0);
-    assert_int_equal(crypto_decrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv, enc, 32, dec), 0);
+    size_t dec_len = 0;
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv,
+                                          plaintext, 32, enc, &enc_len), 0);
+    assert_int_equal(enc_len, 32);
+    assert_int_equal(crypto_decrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv,
+                                          enc, enc_len, dec, &dec_len), 0);
+    assert_int_equal(dec_len, 32);
     assert_memory_equal(dec, plaintext, 32);
+}
+
+static void test_aes_cbc_unaligned(void **state) {
+    (void)state;
+    uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
+    uint8_t iv[CRYPTO_AES_IV_SIZE];
+    assert_int_equal(crypto_init_aes(CRYPTO_AES_KEY_BITS_256, NULL, NULL, key, iv), 0);
+
+    const uint8_t plaintext[] = "unaligned payload";
+    uint8_t enc[32];
+    size_t enc_len = 0;
+    uint8_t dec[32];
+    size_t dec_len = 0;
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv,
+                                          plaintext, sizeof(plaintext) - 1,
+                                          enc, &enc_len), 0);
+    assert_int_equal(enc_len, 32);
+    assert_int_equal(crypto_decrypt_aescbc(key, CRYPTO_AES_KEY_BITS_256, iv,
+                                          enc, enc_len, dec, &dec_len), 0);
+    assert_int_equal(dec_len, sizeof(plaintext) - 1);
+    assert_memory_equal(dec, plaintext, sizeof(plaintext) - 1);
 }
 
 static void test_rsa_sign_verify(void **state) {
@@ -186,10 +213,22 @@ static void test_crypto_encrypt_invalid(void **state) {
     uint8_t iv[CRYPTO_AES_IV_SIZE] = {0};
     uint8_t in[CRYPTO_AES_IV_SIZE] = {0};
     uint8_t out[CRYPTO_AES_IV_SIZE];
-    assert_int_equal(crypto_encrypt_aescbc(NULL, CRYPTO_AES_KEY_BITS_128, iv, in, CRYPTO_AES_IV_SIZE, out), -1);
-    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, NULL, in, CRYPTO_AES_IV_SIZE, out), -1);
-    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv, NULL, CRYPTO_AES_IV_SIZE, out), -1);
-    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv, in, CRYPTO_AES_IV_SIZE, NULL), -1);
+    size_t out_len = 0;
+    assert_int_equal(crypto_encrypt_aescbc(NULL, CRYPTO_AES_KEY_BITS_128, iv,
+                                           in, CRYPTO_AES_IV_SIZE, out,
+                                           &out_len), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, NULL,
+                                           in, CRYPTO_AES_IV_SIZE, out,
+                                           &out_len), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv,
+                                           NULL, CRYPTO_AES_IV_SIZE, out,
+                                           &out_len), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv,
+                                           in, CRYPTO_AES_IV_SIZE, NULL,
+                                           &out_len), -1);
+    assert_int_equal(crypto_encrypt_aescbc(key, CRYPTO_AES_KEY_BITS_128, iv,
+                                           in, CRYPTO_AES_IV_SIZE, out,
+                                           NULL), -1);
 }
 
 static void test_crypto_sign_invalid(void **state) {
@@ -215,6 +254,7 @@ static void test_crypto_verify_invalid(void **state) {
 const struct CMUnitTest crypto_tests[] = {
     cmocka_unit_test(test_sha384),
     cmocka_unit_test(test_aes_cbc),
+    cmocka_unit_test(test_aes_cbc_unaligned),
     cmocka_unit_test(test_rsa_sign_verify),
     cmocka_unit_test(test_lms_sign_verify),
     cmocka_unit_test(test_mldsa_sign_verify),


### PR DESCRIPTION
## Summary
- pad AES-CBC only when input length isn't already a full block
- size allocations using ceiling division rather than unconditional extra block
- adjust AES-CBC tests to match new padding behavior

## Testing
- `scripts/install_third_party.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d1fb93e0833295c6e5b5e9d8789e