### PR TITLE
Document unit tests with descriptive comments

### DIFF
--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -4,6 +4,7 @@
 #include <cmocka.h>
 #include <string.h>
 
+/* Ensure parser rejects an unsupported algorithm argument. */
 void test_cli_invalid_alg(void **state) {
     (void)state;
     char *argv[] = {"prog", "-a", "foo", "-i", "in", "-o", "out", NULL};
@@ -11,6 +12,7 @@ void test_cli_invalid_alg(void **state) {
     assert_int_equal(cli_parse_args(7, argv, &opts), -1);
 }
 
+/* Ensure parser rejects an unsupported AES key size. */
 void test_cli_invalid_bits(void **state) {
     (void)state;
     char *argv[] = {"prog", "-b", "42", "-i", "in", "-o", "out", NULL};
@@ -18,6 +20,7 @@ void test_cli_invalid_bits(void **state) {
     assert_int_equal(cli_parse_args(7, argv, &opts), -1);
 }
 
+/* Verify failure when required input file argument is missing. */
 void test_cli_missing_infile(void **state) {
     (void)state;
     char *argv[] = {"prog", "-o", "out", NULL};
@@ -25,6 +28,7 @@ void test_cli_missing_infile(void **state) {
     assert_int_equal(cli_parse_args(3, argv, &opts), -1);
 }
 
+/* Verify failure when required output file argument is missing. */
 void test_cli_missing_outfile(void **state) {
     (void)state;
     char *argv[] = {"prog", "-i", "in", NULL};
@@ -32,6 +36,7 @@ void test_cli_missing_outfile(void **state) {
     assert_int_equal(cli_parse_args(3, argv, &opts), -1);
 }
 
+/* Parse minimal valid invocation and verify default options. */
 void test_cli_valid_minimal(void **state) {
     (void)state;
     char *argv[] = {"prog", "-i", "in", "-o", "out", NULL};
@@ -43,6 +48,7 @@ void test_cli_valid_minimal(void **state) {
     assert_string_equal(opts.outfile, "out");
 }
 
+/* Accept RSA+LMS algorithm selection. */
 void test_cli_rsa_lms(void **state) {
     (void)state;
     char *argv[] = {"prog", "-a", "rsa-lms", "-i", "in", "-o", "out", NULL};
@@ -51,6 +57,7 @@ void test_cli_rsa_lms(void **state) {
     assert_int_equal(opts.alg, CRYPTO_ALG_RSA4096_LMS);
 }
 
+/* Accept RSA+ML-DSA algorithm selection. */
 void test_cli_rsa_mldsa(void **state) {
     (void)state;
     char *argv[] = {"prog", "-a", "rsa-mldsa87", "-i", "in", "-o", "out", NULL};
@@ -59,6 +66,7 @@ void test_cli_rsa_mldsa(void **state) {
     assert_int_equal(opts.alg, CRYPTO_ALG_RSA4096_MLDSA87);
 }
 
+/* Accept LMS+ML-DSA algorithm selection. */
 void test_cli_lms_mldsa(void **state) {
     (void)state;
     char *argv[] = {"prog", "-a", "lms-mldsa87", "-i", "in", "-o", "out", NULL};

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -7,6 +7,7 @@
 #include <mbedtls/lms.h>
 #include "api.h"
 
+/* Compute SHA-384 of 'abc' and compare against known vector. */
 static void test_sha384(void **state) {
     (void)state;
     uint8_t out[CRYPTO_SHA384_DIGEST_SIZE];
@@ -22,6 +23,7 @@ static void test_sha384(void **state) {
     assert_memory_equal(out, expected, CRYPTO_SHA384_DIGEST_SIZE);
 }
 
+/* Encrypt and decrypt a block-aligned payload with AES-CBC. */
 static void test_aes_cbc(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -43,6 +45,7 @@ static void test_aes_cbc(void **state) {
     assert_memory_equal(dec, plaintext, 32);
 }
 
+/* Encrypt and decrypt data whose length is not a multiple of the block size. */
 static void test_aes_cbc_unaligned(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -64,6 +67,7 @@ static void test_aes_cbc_unaligned(void **state) {
     assert_memory_equal(dec, plaintext, sizeof(plaintext) - 1);
 }
 
+/* Handle AES-CBC operations on an empty plaintext. */
 static void test_aes_cbc_empty(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -83,6 +87,7 @@ static void test_aes_cbc_empty(void **state) {
     assert_int_equal(dec_len, 0);
 }
 
+/* Generate RSA key pair and verify signing round-trip. */
 static void test_rsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -104,6 +109,7 @@ static void test_rsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Generate LMS key pair and verify signing round-trip. */
 static void test_lms_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -127,6 +133,7 @@ static void test_lms_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Generate ML-DSA key pair and verify signing round-trip. */
 static void test_mldsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -146,6 +153,7 @@ static void test_mldsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Verify combined RSA+LMS hybrid signature workflow. */
 static void test_rsa_lms_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -168,6 +176,7 @@ static void test_rsa_lms_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Verify combined RSA+ML-DSA hybrid signature workflow. */
 static void test_rsa_mldsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -188,6 +197,7 @@ static void test_rsa_mldsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Verify combined LMS+ML-DSA hybrid signature workflow. */
 static void test_lms_mldsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -210,6 +220,7 @@ static void test_lms_mldsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Reject invalid parameters to AES initialisation routine. */
 static void test_crypto_init_aes_invalid(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -219,6 +230,7 @@ static void test_crypto_init_aes_invalid(void **state) {
     assert_int_equal(crypto_init_aes(CRYPTO_AES_KEY_BITS_128, NULL, NULL, key, NULL), -1);
 }
 
+/* Reject invalid arguments to SHA-384 helper. */
 static void test_crypto_sha384_invalid(void **state) {
     (void)state;
     uint8_t out[CRYPTO_SHA384_DIGEST_SIZE];
@@ -226,6 +238,7 @@ static void test_crypto_sha384_invalid(void **state) {
     assert_int_equal(crypto_sha384((const uint8_t *)"a", 1, NULL), -1);
 }
 
+/* Reject invalid parameters to AES-CBC encryption. */
 static void test_crypto_encrypt_invalid(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_IV_SIZE] = {0};
@@ -250,6 +263,7 @@ static void test_crypto_encrypt_invalid(void **state) {
                                            NULL), -1);
 }
 
+/* Reject improper arguments to signing function. */
 static void test_crypto_sign_invalid(void **state) {
     (void)state;
     crypto_key priv = {0};
@@ -261,6 +275,7 @@ static void test_crypto_sign_invalid(void **state) {
     assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096, &priv, (uint8_t *)"a", 1, sig, NULL), -1);
 }
 
+/* Reject improper arguments to signature verification function. */
 static void test_crypto_verify_invalid(void **state) {
     (void)state;
     crypto_key pub = {0};


### PR DESCRIPTION
## Summary
- Add explanatory comments before each CLI option unit test.
- Document cryptographic unit tests with brief descriptions of their purpose.

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68ae53d2d2608332b0624d0c491a7510