### PR TITLE
Prefix hex file entries with 0x

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -24,7 +24,7 @@ static int write_bin_hex_pair(const char *bin_path, const char *hex_path,
     if (!f)
         return -1;
     for (size_t i = 0; i < len; i++) {
-        fprintf(f, "%02x", data[i]);
+        fprintf(f, "0x%02x", data[i]);
         if (i + 1 < len)
             fputc(',', f);
     }


### PR DESCRIPTION
## Summary
- prefix hex file outputs with `0x` so keys and ciphertext use consistent hex notation

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeadceae588332b43509a172718689