### PR TITLE
Separate hybrid key outputs

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -74,10 +74,10 @@ int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
                           const crypto_key *pub, crypto_key *out_priv,
                           crypto_key *out_pub);
 
-int crypto_export_keypair_components(crypto_alg alg, const crypto_key *priv,
-                                     const crypto_key *pub,
-                                     crypto_key out_priv[2],
-                                     crypto_key out_pub[2]);
+int crypto_hybrid_export_keypairs(crypto_alg alg, const crypto_key *priv,
+                                  const crypto_key *pub,
+                                  crypto_key out_priv[2],
+                                  crypto_key out_pub[2]);
 
 void crypto_free_key(crypto_key *key);
 

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -79,6 +79,8 @@ int crypto_hybrid_export_keypairs(crypto_alg alg, const crypto_key *priv,
                                   crypto_key out_priv[2],
                                   crypto_key out_pub[2]);
 
+int crypto_hybrid_get_sig_lens(crypto_alg alg, size_t *len1, size_t *len2);
+
 void crypto_free_key(crypto_key *key);
 
 #ifdef __cplusplus

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -74,6 +74,11 @@ int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
                           const crypto_key *pub, crypto_key *out_priv,
                           crypto_key *out_pub);
 
+int crypto_export_keypair_components(crypto_alg alg, const crypto_key *priv,
+                                     const crypto_key *pub,
+                                     crypto_key out_priv[2],
+                                     crypto_key out_pub[2]);
+
 void crypto_free_key(crypto_key *key);
 
 #ifdef __cplusplus

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -676,21 +676,16 @@ static int export_simple(crypto_alg alg, const crypto_key *priv,
     return -1;
 }
 
-int crypto_export_keypair_components(crypto_alg alg, const crypto_key *priv,
-                                     const crypto_key *pub,
-                                     crypto_key out_priv[2],
-                                     crypto_key out_pub[2])
+int crypto_hybrid_export_keypairs(crypto_alg alg, const crypto_key *priv,
+                                  const crypto_key *pub,
+                                  crypto_key out_priv[2],
+                                  crypto_key out_pub[2])
 {
     if (!priv || !pub || !out_priv || !out_pub) {
         return -1;
     }
     memset(out_priv, 0, sizeof(crypto_key) * 2);
     memset(out_pub, 0, sizeof(crypto_key) * 2);
-    if (alg == CRYPTO_ALG_RSA4096 ||
-        alg == CRYPTO_ALG_LMS ||
-        alg == CRYPTO_ALG_MLDSA87) {
-        return export_simple(alg, priv, pub, &out_priv[0], &out_pub[0]);
-    }
     if (alg == CRYPTO_ALG_RSA4096_LMS ||
         alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
         alg == CRYPTO_ALG_LMS_MLDSA87) {

--- a/src/main.c
+++ b/src/main.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
     uint8_t *sig = NULL;
     uint8_t *enc = NULL;
     crypto_key priv = {0}, pub = {0};
-    crypto_key priv_ser = {0}, pub_ser = {0};
 
     /* Load the input file */
     size_t fsize = 0;
@@ -77,20 +76,8 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    const crypto_key *priv_out = &priv;
-    const crypto_key *pub_out  = &pub;
-    if (generate) {
-        if (crypto_export_keypair(opts.alg, &priv, &pub,
-                                  &priv_ser, &pub_ser) != 0) {
-            fprintf(stderr, "Key export failed\n");
-            goto cleanup;
-        }
-        priv_out = &priv_ser;
-        pub_out  = &pub_ser;
-    }
-
     /* Write everything to the requested output */
-    if (write_outputs(opts.outfile, generate, priv_out, pub_out,
+    if (write_outputs(opts.outfile, generate, &priv, &pub,
                       aes_key, opts.aes_bits / 8,
                       iv, sig, sig_len, enc, enc_len) != 0) {
         fprintf(stderr, "Write failed\n");
@@ -103,10 +90,6 @@ cleanup:
     free(buf);
     free(sig);
     free(enc);
-    if (generate) {
-        free(priv_ser.key);
-        free(pub_ser.key);
-    }
     crypto_free_key(&priv); /* pub shares context */
     return ret;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1,171 +1,177 @@
 #include "util.h"
+#include "api.h"
+#include <mbedtls/lms.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <mbedtls/lms.h>
-#include "api.h"
 
-int read_file(const char *path, uint8_t **buf, size_t *len)
-{
-    FILE *f = fopen(path, "rb");
-    if (!f)
-        return -1;
-    fseek(f, 0, SEEK_END);
-    long sz = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    uint8_t *tmp = malloc(sz ? sz : 1);
-    if (!tmp) {
-        fclose(f);
-        return -1;
-    }
-    if (fread(tmp, 1, sz, f) != (size_t)sz) {
-        fclose(f);
-        free(tmp);
-        return -1;
-    }
+int read_file(const char *path, uint8_t **buf, size_t *len) {
+  FILE *f = fopen(path, "rb");
+  if (!f)
+    return -1;
+  fseek(f, 0, SEEK_END);
+  long sz = ftell(f);
+  fseek(f, 0, SEEK_SET);
+  uint8_t *tmp = malloc(sz ? sz : 1);
+  if (!tmp) {
     fclose(f);
-    *buf = tmp;
-    *len = sz;
-    return 0;
+    return -1;
+  }
+  if (fread(tmp, 1, sz, f) != (size_t)sz) {
+    fclose(f);
+    free(tmp);
+    return -1;
+  }
+  fclose(f);
+  *buf = tmp;
+  *len = sz;
+  return 0;
 }
 
 /* write binary and hex representations to files */
 static int write_bin_hex_pair(const char *bin_path, const char *hex_path,
-                              const uint8_t *data, size_t len)
-{
-    FILE *f = fopen(bin_path, "wb");
-    if (!f)
-        return -1;
-    if (fwrite(data, 1, len, f) != len) {
-        fclose(f);
-        return -1;
-    }
+                              const uint8_t *data, size_t len) {
+  FILE *f = fopen(bin_path, "wb");
+  if (!f)
+    return -1;
+  if (fwrite(data, 1, len, f) != len) {
     fclose(f);
+    return -1;
+  }
+  fclose(f);
 
-    f = fopen(hex_path, "w");
-    if (!f)
-        return -1;
-    for (size_t i = 0; i < len; i++) {
-        fprintf(f, "0x%02x", data[i]);
-        if (i + 1 < len)
-            fputc(',', f);
-        if ((i + 1) % 16 == 0)
-            fputc('\n', f);
-    }
-    if (len % 16)
-        fputc('\n', f);
-    fclose(f);
-    return 0;
+  f = fopen(hex_path, "w");
+  if (!f)
+    return -1;
+  for (size_t i = 0; i < len; i++) {
+    fprintf(f, "0x%02x", data[i]);
+    if (i + 1 < len)
+      fputc(',', f);
+    if ((i + 1) % 16 == 0)
+      fputc('\n', f);
+  }
+  if (len % 16)
+    fputc('\n', f);
+  fclose(f);
+  return 0;
 }
 
-static int write_component(const char *name,
-                           const uint8_t *data, size_t len)
-{
-    size_t name_len = strlen(name);
-    char *bin_path = malloc(name_len + 4 + 1);
-    char *hex_path = malloc(name_len + 4 + 1);
-    if (!bin_path || !hex_path) {
-        free(bin_path);
-        free(hex_path);
-        return -1;
-    }
-    sprintf(bin_path, "%s.bin", name);
-    sprintf(hex_path, "%s.hex", name);
-    int ret = write_bin_hex_pair(bin_path, hex_path, data, len);
-    if (ret == 0) {
-        printf("%s binary: %s\n", name, bin_path);
-        printf("%s hex: %s\n", name, hex_path);
-    }
+static int write_component(const char *name, const uint8_t *data, size_t len) {
+  size_t name_len = strlen(name);
+  char *bin_path = malloc(name_len + 4 + 1);
+  char *hex_path = malloc(name_len + 4 + 1);
+  if (!bin_path || !hex_path) {
     free(bin_path);
     free(hex_path);
-    return ret;
+    return -1;
+  }
+  sprintf(bin_path, "%s.bin", name);
+  sprintf(hex_path, "%s.hex", name);
+  int ret = write_bin_hex_pair(bin_path, hex_path, data, len);
+  if (ret == 0) {
+    printf("%s binary: %s\n", name, bin_path);
+    printf("%s hex: %s\n", name, hex_path);
+  }
+  free(bin_path);
+  free(hex_path);
+  return ret;
 }
 
 int write_outputs(const char *out_path, int include_keys,
                   const crypto_key *priv, const crypto_key *pub,
                   const uint8_t aes_key[CRYPTO_AES_MAX_KEY_SIZE],
-                  size_t aes_key_len,
-                  const uint8_t iv[CRYPTO_AES_IV_SIZE],
-                  const uint8_t *sig, size_t sig_len,
-                  const uint8_t *enc, size_t enc_len)
-{
-    size_t out_len = strlen(out_path);
-    char *hex_path = malloc(out_len + 4 + 1);
-    if (!hex_path)
-        return -1;
-    sprintf(hex_path, "%s.hex", out_path);
-    if (write_bin_hex_pair(out_path, hex_path, enc, enc_len) != 0) {
-        free(hex_path);
-        return -1;
-    }
-    printf("ciphertext binary: %s\n", out_path);
-    printf("ciphertext hex: %s\n", hex_path);
+                  size_t aes_key_len, const uint8_t iv[CRYPTO_AES_IV_SIZE],
+                  const uint8_t *sig, size_t sig_len, const uint8_t *enc,
+                  size_t enc_len) {
+  size_t out_len = strlen(out_path);
+  char *hex_path = malloc(out_len + 4 + 1);
+  if (!hex_path)
+    return -1;
+  sprintf(hex_path, "%s.hex", out_path);
+  if (write_bin_hex_pair(out_path, hex_path, enc, enc_len) != 0) {
     free(hex_path);
+    return -1;
+  }
+  printf("ciphertext binary: %s\n", out_path);
+  printf("ciphertext hex: %s\n", hex_path);
+  free(hex_path);
 
-    if (include_keys) {
-        int ret = 0;
-        if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0) {
-            ret = -1;
-        } else if (write_component("aes", aes_key, aes_key_len) != 0) {
-            ret = -1;
-        } else if (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
-                   priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
-                   priv->alg == CRYPTO_ALG_LMS_MLDSA87) {
-            crypto_key privs[2] = {{0}};
-            crypto_key pubs[2] = {{0}};
-            size_t len1 = 0, len2 = 0;
-            if (crypto_hybrid_export_keypairs(priv->alg, priv, pub,
-                                              privs, pubs) != 0) {
-                ret = -1;
-            } else if (priv->alg == CRYPTO_ALG_RSA4096_LMS) {
-                len1 = CRYPTO_RSA_SIG_SIZE;
-                len2 = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                           MBEDTLS_LMOTS_SHA256_N32_W8);
-            } else if (priv->alg == CRYPTO_ALG_RSA4096_MLDSA87) {
-                len1 = CRYPTO_RSA_SIG_SIZE;
-                len2 = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-            } else {
-                len1 = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                           MBEDTLS_LMOTS_SHA256_N32_W8);
-                len2 = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-            }
-            if (ret == 0 && sig_len == len1 + len2) {
-                if (write_component("sk0", privs[0].key, privs[0].key_len) != 0)
-                    ret = -1;
-                else if (write_component("sk1", privs[1].key, privs[1].key_len) != 0)
-                    ret = -1;
-                else if (write_component("pk0", pubs[0].key, pubs[0].key_len) != 0)
-                    ret = -1;
-                else if (write_component("pk1", pubs[1].key, pubs[1].key_len) != 0)
-                    ret = -1;
-                else if (write_component("sig0", sig, len1) != 0)
-                    ret = -1;
-                else if (write_component("sig1", sig + len1, len2) != 0)
-                    ret = -1;
-            } else {
-                ret = -1;
-            }
-            free(privs[0].key);
-            free(privs[1].key);
-            free(pubs[0].key);
-            free(pubs[1].key);
-        } else {
-            crypto_key priv_ser = {0}, pub_ser = {0};
-            if (crypto_export_keypair(priv->alg, priv, pub,
-                                      &priv_ser, &pub_ser) != 0) {
-                ret = -1;
-            } else if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0) {
-                ret = -1;
-            } else if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0) {
-                ret = -1;
-            } else if (write_component("sig0", sig, sig_len) != 0) {
-                ret = -1;
-            }
-            free(priv_ser.key);
-            free(pub_ser.key);
-        }
-        if (ret != 0)
-            return -1;
+  if (include_keys) {
+    int ret = 0;
+    crypto_key privs[2] = {{0}};
+    crypto_key pubs[2] = {{0}};
+    crypto_key priv_ser = {0}, pub_ser = {0};
+    size_t sig_lens[2] = {0};
+    int hybrid = (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
+                  priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
+                  priv->alg == CRYPTO_ALG_LMS_MLDSA87);
+
+    if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0)
+      goto error;
+    if (write_component("aes", aes_key, aes_key_len) != 0)
+      goto error;
+
+    if (hybrid) {
+      if (crypto_hybrid_export_keypairs(priv->alg, priv, pub, privs, pubs) != 0)
+        goto error;
+
+      switch (priv->alg) {
+      case CRYPTO_ALG_RSA4096_LMS:
+        sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
+        sig_lens[1] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
+                                          MBEDTLS_LMOTS_SHA256_N32_W8);
+        break;
+      case CRYPTO_ALG_RSA4096_MLDSA87:
+        sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
+        sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        break;
+      case CRYPTO_ALG_LMS_MLDSA87:
+        sig_lens[0] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
+                                          MBEDTLS_LMOTS_SHA256_N32_W8);
+        sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        break;
+      default:
+        goto error;
+      }
+
+      if (sig_len != sig_lens[0] + sig_lens[1])
+        goto error;
+      if (write_component("sk0", privs[0].key, privs[0].key_len) != 0)
+        goto error;
+      if (write_component("sk1", privs[1].key, privs[1].key_len) != 0)
+        goto error;
+      if (write_component("pk0", pubs[0].key, pubs[0].key_len) != 0)
+        goto error;
+      if (write_component("pk1", pubs[1].key, pubs[1].key_len) != 0)
+        goto error;
+      if (write_component("sig0", sig, sig_lens[0]) != 0)
+        goto error;
+      if (write_component("sig1", sig + sig_lens[0], sig_lens[1]) != 0)
+        goto error;
+    } else {
+      if (crypto_export_keypair(priv->alg, priv, pub, &priv_ser, &pub_ser) != 0)
+        goto error;
+      if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0)
+        goto error;
+      if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0)
+        goto error;
+      if (write_component("sig0", sig, sig_len) != 0)
+        goto error;
     }
-    return 0;
+    goto cleanup;
+
+  error:
+    ret = -1;
+
+  cleanup:
+    free(privs[0].key);
+    free(privs[1].key);
+    free(pubs[0].key);
+    free(pubs[1].key);
+    free(priv_ser.key);
+    free(pub_ser.key);
+    if (ret != 0)
+      return -1;
+  }
+  return 0;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -104,20 +104,20 @@ int write_outputs(const char *out_path, int include_keys,
 
     if (include_keys) {
         int ret = 0;
-        if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0)
+        if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0) {
             ret = -1;
-        else if (write_component("aes", aes_key, aes_key_len) != 0)
+        } else if (write_component("aes", aes_key, aes_key_len) != 0) {
             ret = -1;
-        else if (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
-                 priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
-                 priv->alg == CRYPTO_ALG_LMS_MLDSA87) {
+        } else if (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
+                   priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
+                   priv->alg == CRYPTO_ALG_LMS_MLDSA87) {
             crypto_key privs[2] = {{0}};
             crypto_key pubs[2] = {{0}};
             size_t len1 = 0, len2 = 0;
-            if (crypto_export_keypair_components(priv->alg, priv, pub,
-                                                 privs, pubs) != 0)
+            if (crypto_hybrid_export_keypairs(priv->alg, priv, pub,
+                                              privs, pubs) != 0) {
                 ret = -1;
-            else if (priv->alg == CRYPTO_ALG_RSA4096_LMS) {
+            } else if (priv->alg == CRYPTO_ALG_RSA4096_LMS) {
                 len1 = CRYPTO_RSA_SIG_SIZE;
                 len2 = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
                                            MBEDTLS_LMOTS_SHA256_N32_W8);
@@ -152,14 +152,15 @@ int write_outputs(const char *out_path, int include_keys,
         } else {
             crypto_key priv_ser = {0}, pub_ser = {0};
             if (crypto_export_keypair(priv->alg, priv, pub,
-                                      &priv_ser, &pub_ser) != 0)
+                                      &priv_ser, &pub_ser) != 0) {
                 ret = -1;
-            else if (write_component("sk", priv_ser.key, priv_ser.key_len) != 0)
+            } else if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0) {
                 ret = -1;
-            else if (write_component("pk", pub_ser.key, pub_ser.key_len) != 0)
+            } else if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0) {
                 ret = -1;
-            else if (write_component("sig", sig, sig_len) != 0)
+            } else if (write_component("sig0", sig, sig_len) != 0) {
                 ret = -1;
+            }
             free(priv_ser.key);
             free(pub_ser.key);
         }

--- a/src/util.c
+++ b/src/util.c
@@ -140,22 +140,8 @@ int write_outputs(const char *out_path, int include_keys,
                 goto error;
             }
 
-            switch (priv->alg) {
-            case CRYPTO_ALG_RSA4096_LMS:
-                sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
-                sig_lens[1] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                                  MBEDTLS_LMOTS_SHA256_N32_W8);
-                break;
-            case CRYPTO_ALG_RSA4096_MLDSA87:
-                sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
-                sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-                break;
-            case CRYPTO_ALG_LMS_MLDSA87:
-                sig_lens[0] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                                  MBEDTLS_LMOTS_SHA256_N32_W8);
-                sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-                break;
-            default:
+            if (crypto_hybrid_get_sig_lens(priv->alg, &sig_lens[0],
+                                           &sig_lens[1]) != 0) {
                 goto error;
             }
 

--- a/src/util.c
+++ b/src/util.c
@@ -5,76 +5,95 @@
 #include <stdlib.h>
 #include <string.h>
 
-int read_file(const char *path, uint8_t **buf, size_t *len) {
-  FILE *f = fopen(path, "rb");
-  if (!f)
-    return -1;
-  fseek(f, 0, SEEK_END);
-  long sz = ftell(f);
-  fseek(f, 0, SEEK_SET);
-  uint8_t *tmp = malloc(sz ? sz : 1);
-  if (!tmp) {
-    fclose(f);
-    return -1;
-  }
-  if (fread(tmp, 1, sz, f) != (size_t)sz) {
-    fclose(f);
+int read_file(const char *path, uint8_t **buf, size_t *len)
+{
+    int ret = -1;
+    FILE *f = fopen(path, "rb");
+    uint8_t *tmp = NULL;
+    if (f == NULL) {
+        goto cleanup;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    if (sz <= 0) {
+        goto cleanup;
+    }
+    fseek(f, 0, SEEK_SET);
+    tmp = malloc(sz);
+    if (tmp == NULL) {
+        goto cleanup;
+    }
+    if (fread(tmp, 1, sz, f) != (size_t)sz) {
+        goto cleanup;
+    }
+    *buf = tmp;
+    *len = sz;
+    tmp = NULL;
+    ret = 0;
+
+cleanup:
     free(tmp);
-    return -1;
-  }
-  fclose(f);
-  *buf = tmp;
-  *len = sz;
-  return 0;
+    if (f != NULL) {
+        fclose(f);
+    }
+    return ret;
 }
 
 /* write binary and hex representations to files */
 static int write_bin_hex_pair(const char *bin_path, const char *hex_path,
-                              const uint8_t *data, size_t len) {
-  FILE *f = fopen(bin_path, "wb");
-  if (!f)
-    return -1;
-  if (fwrite(data, 1, len, f) != len) {
+                              const uint8_t *data, size_t len)
+{
+    FILE *f = fopen(bin_path, "wb");
+    if (f == NULL) {
+        return -1;
+    }
+    if (fwrite(data, 1, len, f) != len) {
+        fclose(f);
+        return -1;
+    }
     fclose(f);
-    return -1;
-  }
-  fclose(f);
 
-  f = fopen(hex_path, "w");
-  if (!f)
-    return -1;
-  for (size_t i = 0; i < len; i++) {
-    fprintf(f, "0x%02x", data[i]);
-    if (i + 1 < len)
-      fputc(',', f);
-    if ((i + 1) % 16 == 0)
-      fputc('\n', f);
-  }
-  if (len % 16)
-    fputc('\n', f);
-  fclose(f);
-  return 0;
+    f = fopen(hex_path, "w");
+    if (f == NULL) {
+        return -1;
+    }
+    for (size_t i = 0; i < len; i++) {
+        fprintf(f, "0x%02x", data[i]);
+        if (i + 1 < len) {
+            fputc(',', f);
+        }
+        if ((i + 1) % 16 == 0) {
+            fputc('\n', f);
+        }
+    }
+    if (len % 16) {
+        fputc('\n', f);
+    }
+    fclose(f);
+    return 0;
 }
 
-static int write_component(const char *name, const uint8_t *data, size_t len) {
-  size_t name_len = strlen(name);
-  char *bin_path = malloc(name_len + 4 + 1);
-  char *hex_path = malloc(name_len + 4 + 1);
-  if (!bin_path || !hex_path) {
+static int write_component(const char *name, const uint8_t *data, size_t len)
+{
+    size_t name_len = strlen(name);
+    char *bin_path = malloc(name_len + 4 + 1);
+    char *hex_path = malloc(name_len + 4 + 1);
+    if (bin_path == NULL || hex_path == NULL) {
+        free(bin_path);
+        free(hex_path);
+        return -1;
+    }
+    sprintf(bin_path, "%s.bin", name);
+    sprintf(hex_path, "%s.hex", name);
+    int ret = write_bin_hex_pair(bin_path, hex_path, data, len);
+    if (ret == 0) {
+        printf("%s binary: %s\n", name, bin_path);
+        printf("%s hex: %s\n", name, hex_path);
+    }
     free(bin_path);
     free(hex_path);
-    return -1;
-  }
-  sprintf(bin_path, "%s.bin", name);
-  sprintf(hex_path, "%s.hex", name);
-  int ret = write_bin_hex_pair(bin_path, hex_path, data, len);
-  if (ret == 0) {
-    printf("%s binary: %s\n", name, bin_path);
-    printf("%s hex: %s\n", name, hex_path);
-  }
-  free(bin_path);
-  free(hex_path);
-  return ret;
+    return ret;
 }
 
 int write_outputs(const char *out_path, int include_keys,
@@ -82,96 +101,115 @@ int write_outputs(const char *out_path, int include_keys,
                   const uint8_t aes_key[CRYPTO_AES_MAX_KEY_SIZE],
                   size_t aes_key_len, const uint8_t iv[CRYPTO_AES_IV_SIZE],
                   const uint8_t *sig, size_t sig_len, const uint8_t *enc,
-                  size_t enc_len) {
-  size_t out_len = strlen(out_path);
-  char *hex_path = malloc(out_len + 4 + 1);
-  if (!hex_path)
-    return -1;
-  sprintf(hex_path, "%s.hex", out_path);
-  if (write_bin_hex_pair(out_path, hex_path, enc, enc_len) != 0) {
-    free(hex_path);
-    return -1;
-  }
-  printf("ciphertext binary: %s\n", out_path);
-  printf("ciphertext hex: %s\n", hex_path);
-  free(hex_path);
-
-  if (include_keys) {
-    int ret = 0;
-    crypto_key privs[2] = {{0}};
-    crypto_key pubs[2] = {{0}};
-    crypto_key priv_ser = {0}, pub_ser = {0};
-    size_t sig_lens[2] = {0};
-    int hybrid = (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
-                  priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
-                  priv->alg == CRYPTO_ALG_LMS_MLDSA87);
-
-    if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0)
-      goto error;
-    if (write_component("aes", aes_key, aes_key_len) != 0)
-      goto error;
-
-    if (hybrid) {
-      if (crypto_hybrid_export_keypairs(priv->alg, priv, pub, privs, pubs) != 0)
-        goto error;
-
-      switch (priv->alg) {
-      case CRYPTO_ALG_RSA4096_LMS:
-        sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
-        sig_lens[1] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                          MBEDTLS_LMOTS_SHA256_N32_W8);
-        break;
-      case CRYPTO_ALG_RSA4096_MLDSA87:
-        sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
-        sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-        break;
-      case CRYPTO_ALG_LMS_MLDSA87:
-        sig_lens[0] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                          MBEDTLS_LMOTS_SHA256_N32_W8);
-        sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-        break;
-      default:
-        goto error;
-      }
-
-      if (sig_len != sig_lens[0] + sig_lens[1])
-        goto error;
-      if (write_component("sk0", privs[0].key, privs[0].key_len) != 0)
-        goto error;
-      if (write_component("sk1", privs[1].key, privs[1].key_len) != 0)
-        goto error;
-      if (write_component("pk0", pubs[0].key, pubs[0].key_len) != 0)
-        goto error;
-      if (write_component("pk1", pubs[1].key, pubs[1].key_len) != 0)
-        goto error;
-      if (write_component("sig0", sig, sig_lens[0]) != 0)
-        goto error;
-      if (write_component("sig1", sig + sig_lens[0], sig_lens[1]) != 0)
-        goto error;
-    } else {
-      if (crypto_export_keypair(priv->alg, priv, pub, &priv_ser, &pub_ser) != 0)
-        goto error;
-      if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0)
-        goto error;
-      if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0)
-        goto error;
-      if (write_component("sig0", sig, sig_len) != 0)
-        goto error;
+                  size_t enc_len)
+{
+    size_t out_len = strlen(out_path);
+    char *hex_path = malloc(out_len + 4 + 1);
+    if (hex_path == NULL) {
+        return -1;
     }
-    goto cleanup;
+    sprintf(hex_path, "%s.hex", out_path);
+    if (write_bin_hex_pair(out_path, hex_path, enc, enc_len) != 0) {
+        free(hex_path);
+        return -1;
+    }
+    printf("ciphertext binary: %s\n", out_path);
+    printf("ciphertext hex: %s\n", hex_path);
+    free(hex_path);
 
-  error:
-    ret = -1;
+    if (include_keys) {
+        int ret = 0;
+        crypto_key privs[2] = {{0}};
+        crypto_key pubs[2] = {{0}};
+        crypto_key priv_ser = {0}, pub_ser = {0};
+        size_t sig_lens[2] = {0};
+        int hybrid = (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
+                      priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
+                      priv->alg == CRYPTO_ALG_LMS_MLDSA87);
 
-  cleanup:
-    free(privs[0].key);
-    free(privs[1].key);
-    free(pubs[0].key);
-    free(pubs[1].key);
-    free(priv_ser.key);
-    free(pub_ser.key);
-    if (ret != 0)
-      return -1;
-  }
-  return 0;
+        if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0) {
+            goto error;
+        }
+        if (write_component("aes", aes_key, aes_key_len) != 0) {
+            goto error;
+        }
+
+        if (hybrid) {
+            if (crypto_hybrid_export_keypairs(priv->alg, priv, pub, privs,
+                                              pubs) != 0) {
+                goto error;
+            }
+
+            switch (priv->alg) {
+            case CRYPTO_ALG_RSA4096_LMS:
+                sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
+                sig_lens[1] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
+                                                  MBEDTLS_LMOTS_SHA256_N32_W8);
+                break;
+            case CRYPTO_ALG_RSA4096_MLDSA87:
+                sig_lens[0] = CRYPTO_RSA_SIG_SIZE;
+                sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+                break;
+            case CRYPTO_ALG_LMS_MLDSA87:
+                sig_lens[0] = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
+                                                  MBEDTLS_LMOTS_SHA256_N32_W8);
+                sig_lens[1] = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+                break;
+            default:
+                goto error;
+            }
+
+            if (sig_len != sig_lens[0] + sig_lens[1]) {
+                goto error;
+            }
+            if (write_component("sk0", privs[0].key, privs[0].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("sk1", privs[1].key, privs[1].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("pk0", pubs[0].key, pubs[0].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("pk1", pubs[1].key, pubs[1].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("sig0", sig, sig_lens[0]) != 0) {
+                goto error;
+            }
+            if (write_component("sig1", sig + sig_lens[0], sig_lens[1]) != 0) {
+                goto error;
+            }
+        } else {
+            if (crypto_export_keypair(priv->alg, priv, pub, &priv_ser,
+                                      &pub_ser) != 0) {
+                goto error;
+            }
+            if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0) {
+                goto error;
+            }
+            if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0) {
+                goto error;
+            }
+            if (write_component("sig0", sig, sig_len) != 0) {
+                goto error;
+            }
+        }
+        goto cleanup;
+
+    error:
+        ret = -1;
+
+    cleanup:
+        free(privs[0].key);
+        free(privs[1].key);
+        free(pubs[0].key);
+        free(pubs[1].key);
+        free(priv_ser.key);
+        free(pub_ser.key);
+        if (ret != 0) {
+            return -1;
+        }
+    }
+    return 0;
 }

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -346,8 +346,8 @@ static void outputs_roundtrip(crypto_alg alg) {
     if (alg == CRYPTO_ALG_RSA4096_LMS ||
         alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
         alg == CRYPTO_ALG_LMS_MLDSA87) {
-        assert_int_equal(crypto_export_keypair_components(alg, &priv, &pub,
-                                                          priv_ser, pub_ser), 0);
+        assert_int_equal(crypto_hybrid_export_keypairs(alg, &priv, &pub,
+                                                      priv_ser, pub_ser), 0);
         key_count = 2;
     } else {
         assert_int_equal(crypto_export_keypair(alg, &priv, &pub,
@@ -364,19 +364,19 @@ static void outputs_roundtrip(crypto_alg alg) {
     comps[comp_idx].data = aes_key;
     comps[comp_idx].len  = CRYPTO_AES_KEY_BITS_128 / 8;
     comp_idx++;
+    for (size_t i = 0; i < key_count; i++) {
+        sprintf(comps[comp_idx].name, "sk%zu", i);
+        comps[comp_idx].data = priv_ser[i].key;
+        comps[comp_idx].len  = priv_ser[i].key_len;
+        comp_idx++;
+    }
+    for (size_t i = 0; i < key_count; i++) {
+        sprintf(comps[comp_idx].name, "pk%zu", i);
+        comps[comp_idx].data = pub_ser[i].key;
+        comps[comp_idx].len  = pub_ser[i].key_len;
+        comp_idx++;
+    }
     if (key_count == 2) {
-        for (size_t i = 0; i < key_count; i++) {
-            sprintf(comps[comp_idx].name, "sk%zu", i);
-            comps[comp_idx].data = priv_ser[i].key;
-            comps[comp_idx].len  = priv_ser[i].key_len;
-            comp_idx++;
-        }
-        for (size_t i = 0; i < key_count; i++) {
-            sprintf(comps[comp_idx].name, "pk%zu", i);
-            comps[comp_idx].data = pub_ser[i].key;
-            comps[comp_idx].len  = pub_ser[i].key_len;
-            comp_idx++;
-        }
         size_t len1 = 0, len2 = 0;
         if (alg == CRYPTO_ALG_RSA4096_LMS) {
             len1 = CRYPTO_RSA_SIG_SIZE;
@@ -399,15 +399,7 @@ static void outputs_roundtrip(crypto_alg alg) {
         comps[comp_idx].len  = len2;
         comp_idx++;
     } else {
-        strcpy(comps[comp_idx].name, "sk");
-        comps[comp_idx].data = priv_ser[0].key;
-        comps[comp_idx].len  = priv_ser[0].key_len;
-        comp_idx++;
-        strcpy(comps[comp_idx].name, "pk");
-        comps[comp_idx].data = pub_ser[0].key;
-        comps[comp_idx].len  = pub_ser[0].key_len;
-        comp_idx++;
-        strcpy(comps[comp_idx].name, "sig");
+        strcpy(comps[comp_idx].name, "sig0");
         comps[comp_idx].data = sig;
         comps[comp_idx].len  = sig_len;
         comp_idx++;

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -328,11 +328,7 @@ static void outputs_roundtrip(crypto_alg alg) {
     assert_true(fd != -1);
     close(fd);
 
-    crypto_key priv_ser = {0}, pub_ser = {0};
-    assert_int_equal(crypto_export_keypair(alg, &priv, &pub,
-                                           &priv_ser, &pub_ser), 0);
-
-    assert_int_equal(write_outputs(out_path, 1, &priv_ser, &pub_ser,
+    assert_int_equal(write_outputs(out_path, 1, &priv, &pub,
                                    aes_key, CRYPTO_AES_KEY_BITS_128 / 8,
                                    iv, sig, sig_len, enc, enc_len), 0);
 
@@ -344,14 +340,80 @@ static void outputs_roundtrip(crypto_alg alg) {
     free(tmp);
 
     char path[64];
-    const struct { const char *name; const uint8_t *data; size_t len; } comps[] = {
-        {"aes_iv", iv, CRYPTO_AES_IV_SIZE},
-        {"aes", aes_key, CRYPTO_AES_KEY_BITS_128 / 8},
-        {"sk", priv_ser.key, priv_ser.key_len},
-        {"pk", pub_ser.key, pub_ser.key_len},
-        {"sig", sig, sig_len},
-    };
-    for (size_t i = 0; i < sizeof(comps)/sizeof(comps[0]); i++) {
+    crypto_key priv_ser[2] = {{0}};
+    crypto_key pub_ser[2] = {{0}};
+    size_t key_count = 1;
+    if (alg == CRYPTO_ALG_RSA4096_LMS ||
+        alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
+        alg == CRYPTO_ALG_LMS_MLDSA87) {
+        assert_int_equal(crypto_export_keypair_components(alg, &priv, &pub,
+                                                          priv_ser, pub_ser), 0);
+        key_count = 2;
+    } else {
+        assert_int_equal(crypto_export_keypair(alg, &priv, &pub,
+                                              &priv_ser[0], &pub_ser[0]), 0);
+    }
+
+    struct { char name[8]; const uint8_t *data; size_t len; } comps[9];
+    size_t comp_idx = 0;
+    strcpy(comps[comp_idx].name, "aes_iv");
+    comps[comp_idx].data = iv;
+    comps[comp_idx].len  = CRYPTO_AES_IV_SIZE;
+    comp_idx++;
+    strcpy(comps[comp_idx].name, "aes");
+    comps[comp_idx].data = aes_key;
+    comps[comp_idx].len  = CRYPTO_AES_KEY_BITS_128 / 8;
+    comp_idx++;
+    if (key_count == 2) {
+        for (size_t i = 0; i < key_count; i++) {
+            sprintf(comps[comp_idx].name, "sk%zu", i);
+            comps[comp_idx].data = priv_ser[i].key;
+            comps[comp_idx].len  = priv_ser[i].key_len;
+            comp_idx++;
+        }
+        for (size_t i = 0; i < key_count; i++) {
+            sprintf(comps[comp_idx].name, "pk%zu", i);
+            comps[comp_idx].data = pub_ser[i].key;
+            comps[comp_idx].len  = pub_ser[i].key_len;
+            comp_idx++;
+        }
+        size_t len1 = 0, len2 = 0;
+        if (alg == CRYPTO_ALG_RSA4096_LMS) {
+            len1 = CRYPTO_RSA_SIG_SIZE;
+            len2 = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
+                                       MBEDTLS_LMOTS_SHA256_N32_W8);
+        } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
+            len1 = CRYPTO_RSA_SIG_SIZE;
+            len2 = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        } else {
+            len1 = MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
+                                       MBEDTLS_LMOTS_SHA256_N32_W8);
+            len2 = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        }
+        sprintf(comps[comp_idx].name, "sig0");
+        comps[comp_idx].data = sig;
+        comps[comp_idx].len  = len1;
+        comp_idx++;
+        sprintf(comps[comp_idx].name, "sig1");
+        comps[comp_idx].data = sig + len1;
+        comps[comp_idx].len  = len2;
+        comp_idx++;
+    } else {
+        strcpy(comps[comp_idx].name, "sk");
+        comps[comp_idx].data = priv_ser[0].key;
+        comps[comp_idx].len  = priv_ser[0].key_len;
+        comp_idx++;
+        strcpy(comps[comp_idx].name, "pk");
+        comps[comp_idx].data = pub_ser[0].key;
+        comps[comp_idx].len  = pub_ser[0].key_len;
+        comp_idx++;
+        strcpy(comps[comp_idx].name, "sig");
+        comps[comp_idx].data = sig;
+        comps[comp_idx].len  = sig_len;
+        comp_idx++;
+    }
+
+    for (size_t i = 0; i < comp_idx; i++) {
         sprintf(path, "%s.bin", comps[i].name);
         tmp = NULL;
         len = 0;
@@ -373,8 +435,10 @@ static void outputs_roundtrip(crypto_alg alg) {
 
     free(sig);
     free(enc);
-    free(priv_ser.key);
-    free(pub_ser.key);
+    for (size_t i = 0; i < key_count; i++) {
+        free(priv_ser[i].key);
+        free(pub_ser[i].key);
+    }
     void *shared = (priv.key == pub.key) ? priv.key : NULL;
     crypto_free_key(&priv);
     if (shared)


### PR DESCRIPTION
## Summary
- export individual keys for hybrid algorithms via new crypto_export_keypair_components API
- write hybrid signatures and keypairs to indexed files (pk0/pk1 etc.)
- update tests and main to handle separated outputs

## Testing
- `scripts/install_third_party.sh`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b69c07d6d483329cc971837da0cf1f