### PR TITLE
Separate hybrid key outputs

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -74,6 +74,16 @@ int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
                           const crypto_key *pub, crypto_key *out_priv,
                           crypto_key *out_pub);
 
+int crypto_hybrid_export_keypairs(crypto_alg alg, const crypto_key *priv,
+                                  const crypto_key *pub,
+                                  crypto_key out_priv[2],
+                                  crypto_key out_pub[2]);
+
+int crypto_hybrid_get_algs(crypto_alg alg, crypto_alg *first,
+                           crypto_alg *second);
+
+int crypto_hybrid_get_sig_lens(crypto_alg alg, size_t *len1, size_t *len2);
+
 void crypto_free_key(crypto_key *key);
 
 #ifdef __cplusplus

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -176,16 +176,11 @@ int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub)
         if (!pair) {
             return -1;
         }
-        crypto_alg first, second;
-        if (alg == CRYPTO_ALG_RSA4096_LMS) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_LMS;
-        } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_MLDSA87;
-        } else {
-            first  = CRYPTO_ALG_LMS;
-            second = CRYPTO_ALG_MLDSA87;
+        crypto_alg first;
+        crypto_alg second;
+        if (crypto_hybrid_get_algs(alg, &first, &second) != 0) {
+            free(pair);
+            return -1;
         }
         if (crypto_keygen(first, &pair->first_priv, &pair->first_pub) != 0 ||
             crypto_keygen(second, &pair->second_priv, &pair->second_pub) != 0) {
@@ -349,22 +344,13 @@ int crypto_sign(crypto_alg alg, const crypto_key *priv, const uint8_t *msg, size
         hybrid_pair *pair = priv->key;
         size_t len1 = 0;
         size_t len2 = 0;
-        crypto_alg first, second;
-        if (alg == CRYPTO_ALG_RSA4096_LMS) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_LMS;
-            len1   = CRYPTO_RSA_SIG_SIZE;
-            len2   = LMS_SIG_LEN;
-        } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_MLDSA87;
-            len1   = CRYPTO_RSA_SIG_SIZE;
-            len2   = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-        } else {
-            first  = CRYPTO_ALG_LMS;
-            second = CRYPTO_ALG_MLDSA87;
-            len1   = LMS_SIG_LEN;
-            len2   = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        crypto_alg first;
+        crypto_alg second;
+        if (crypto_hybrid_get_algs(alg, &first, &second) != 0 ||
+            crypto_hybrid_get_sig_lens(alg, &len1, &len2) != 0) {
+            mbedtls_ctr_drbg_free(&drbg);
+            mbedtls_entropy_free(&entropy);
+            return -1;
         }
         size_t tmp = len1;
         if (crypto_sign(first, &pair->first_priv, msg, msg_len, sig, &tmp) != 0 ||
@@ -425,22 +411,11 @@ int crypto_verify(crypto_alg alg, const crypto_key *pub, const uint8_t *msg, siz
         hybrid_pair *pair = pub->key;
         size_t len1 = 0;
         size_t len2 = 0;
-        crypto_alg first, second;
-        if (alg == CRYPTO_ALG_RSA4096_LMS) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_LMS;
-            len1   = CRYPTO_RSA_SIG_SIZE;
-            len2   = LMS_SIG_LEN;
-        } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_MLDSA87;
-            len1   = CRYPTO_RSA_SIG_SIZE;
-            len2   = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
-        } else {
-            first  = CRYPTO_ALG_LMS;
-            second = CRYPTO_ALG_MLDSA87;
-            len1   = LMS_SIG_LEN;
-            len2   = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        crypto_alg first;
+        crypto_alg second;
+        if (crypto_hybrid_get_algs(alg, &first, &second) != 0 ||
+            crypto_hybrid_get_sig_lens(alg, &len1, &len2) != 0) {
+            return -1;
         }
         if (sig_len != len1 + len2) {
             return -1;
@@ -676,6 +651,78 @@ static int export_simple(crypto_alg alg, const crypto_key *priv,
     return -1;
 }
 
+int crypto_hybrid_get_algs(crypto_alg alg, crypto_alg *first,
+                           crypto_alg *second)
+{
+    if (first == NULL || second == NULL) {
+        return -1;
+    }
+    if (alg == CRYPTO_ALG_RSA4096_LMS) {
+        *first  = CRYPTO_ALG_RSA4096;
+        *second = CRYPTO_ALG_LMS;
+        return 0;
+    } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
+        *first  = CRYPTO_ALG_RSA4096;
+        *second = CRYPTO_ALG_MLDSA87;
+        return 0;
+    } else if (alg == CRYPTO_ALG_LMS_MLDSA87) {
+        *first  = CRYPTO_ALG_LMS;
+        *second = CRYPTO_ALG_MLDSA87;
+        return 0;
+    }
+    return -1;
+}
+
+int crypto_hybrid_export_keypairs(crypto_alg alg, const crypto_key *priv,
+                                  const crypto_key *pub,
+                                  crypto_key out_priv[2],
+                                  crypto_key out_pub[2])
+{
+    if (!priv || !pub || !out_priv || !out_pub) {
+        return -1;
+    }
+    memset(out_priv, 0, sizeof(crypto_key) * 2);
+    memset(out_pub, 0, sizeof(crypto_key) * 2);
+    const hybrid_pair *pair = priv->key;
+    crypto_alg first;
+    crypto_alg second;
+    if (crypto_hybrid_get_algs(alg, &first, &second) != 0 ||
+        export_simple(first, &pair->first_priv, &pair->first_pub,
+                      &out_priv[0], &out_pub[0]) != 0 ||
+        export_simple(second, &pair->second_priv, &pair->second_pub,
+                      &out_priv[1], &out_pub[1]) != 0) {
+        free(out_priv[0].key);
+        free(out_pub[0].key);
+        free(out_priv[1].key);
+        free(out_pub[1].key);
+        memset(out_priv, 0, sizeof(crypto_key) * 2);
+        memset(out_pub, 0, sizeof(crypto_key) * 2);
+        return -1;
+    }
+    return 0;
+}
+
+int crypto_hybrid_get_sig_lens(crypto_alg alg, size_t *len1, size_t *len2)
+{
+    if (len1 == NULL || len2 == NULL) {
+        return -1;
+    }
+    if (alg == CRYPTO_ALG_RSA4096_LMS) {
+        *len1 = CRYPTO_RSA_SIG_SIZE;
+        *len2 = LMS_SIG_LEN;
+        return 0;
+    } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
+        *len1 = CRYPTO_RSA_SIG_SIZE;
+        *len2 = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        return 0;
+    } else if (alg == CRYPTO_ALG_LMS_MLDSA87) {
+        *len1 = LMS_SIG_LEN;
+        *len2 = PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES;
+        return 0;
+    }
+    return -1;
+}
+
 int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
                           const crypto_key *pub, crypto_key *out_priv,
                           crypto_key *out_pub)
@@ -689,16 +736,10 @@ int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
         const hybrid_pair *pair = priv->key;
         crypto_key first_priv = {0}, first_pub = {0};
         crypto_key second_priv = {0}, second_pub = {0};
-        crypto_alg first, second;
-        if (alg == CRYPTO_ALG_RSA4096_LMS) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_LMS;
-        } else if (alg == CRYPTO_ALG_RSA4096_MLDSA87) {
-            first  = CRYPTO_ALG_RSA4096;
-            second = CRYPTO_ALG_MLDSA87;
-        } else {
-            first  = CRYPTO_ALG_LMS;
-            second = CRYPTO_ALG_MLDSA87;
+        crypto_alg first;
+        crypto_alg second;
+        if (crypto_hybrid_get_algs(alg, &first, &second) != 0) {
+            return -1;
         }
         int ret = -1;
         if (export_simple(first, &pair->first_priv, &pair->first_pub,

--- a/src/main.c
+++ b/src/main.c
@@ -29,7 +29,6 @@ int main(int argc, char **argv)
     uint8_t *sig = NULL;
     uint8_t *enc = NULL;
     crypto_key priv = {0}, pub = {0};
-    crypto_key priv_ser = {0}, pub_ser = {0};
 
     /* Load the input file */
     size_t fsize = 0;
@@ -77,20 +76,8 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    const crypto_key *priv_out = &priv;
-    const crypto_key *pub_out  = &pub;
-    if (generate) {
-        if (crypto_export_keypair(opts.alg, &priv, &pub,
-                                  &priv_ser, &pub_ser) != 0) {
-            fprintf(stderr, "Key export failed\n");
-            goto cleanup;
-        }
-        priv_out = &priv_ser;
-        pub_out  = &pub_ser;
-    }
-
     /* Write everything to the requested output */
-    if (write_outputs(opts.outfile, generate, priv_out, pub_out,
+    if (write_outputs(opts.outfile, generate, &priv, &pub,
                       aes_key, opts.aes_bits / 8,
                       iv, sig, sig_len, enc, enc_len) != 0) {
         fprintf(stderr, "Write failed\n");
@@ -103,10 +90,6 @@ cleanup:
     free(buf);
     free(sig);
     free(enc);
-    if (generate) {
-        free(priv_ser.key);
-        free(pub_ser.key);
-    }
     crypto_free_key(&priv); /* pub shares context */
     return ret;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -1,30 +1,43 @@
 #include "util.h"
+#include "api.h"
+#include <mbedtls/lms.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 int read_file(const char *path, uint8_t **buf, size_t *len)
 {
+    int ret = -1;
     FILE *f = fopen(path, "rb");
-    if (!f)
-        return -1;
+    uint8_t *tmp = NULL;
+    if (f == NULL) {
+        goto cleanup;
+    }
+
     fseek(f, 0, SEEK_END);
     long sz = ftell(f);
+    if (sz <= 0) {
+        goto cleanup;
+    }
     fseek(f, 0, SEEK_SET);
-    uint8_t *tmp = malloc(sz ? sz : 1);
-    if (!tmp) {
-        fclose(f);
-        return -1;
+    tmp = malloc(sz);
+    if (tmp == NULL) {
+        goto cleanup;
     }
     if (fread(tmp, 1, sz, f) != (size_t)sz) {
-        fclose(f);
-        free(tmp);
-        return -1;
+        goto cleanup;
     }
-    fclose(f);
     *buf = tmp;
     *len = sz;
-    return 0;
+    tmp = NULL;
+    ret = 0;
+
+cleanup:
+    free(tmp);
+    if (f != NULL) {
+        fclose(f);
+    }
+    return ret;
 }
 
 /* write binary and hex representations to files */
@@ -32,8 +45,9 @@ static int write_bin_hex_pair(const char *bin_path, const char *hex_path,
                               const uint8_t *data, size_t len)
 {
     FILE *f = fopen(bin_path, "wb");
-    if (!f)
+    if (f == NULL) {
         return -1;
+    }
     if (fwrite(data, 1, len, f) != len) {
         fclose(f);
         return -1;
@@ -41,28 +55,31 @@ static int write_bin_hex_pair(const char *bin_path, const char *hex_path,
     fclose(f);
 
     f = fopen(hex_path, "w");
-    if (!f)
+    if (f == NULL) {
         return -1;
+    }
     for (size_t i = 0; i < len; i++) {
         fprintf(f, "0x%02x", data[i]);
-        if (i + 1 < len)
+        if (i + 1 < len) {
             fputc(',', f);
-        if ((i + 1) % 16 == 0)
+        }
+        if ((i + 1) % 16 == 0) {
             fputc('\n', f);
+        }
     }
-    if (len % 16)
+    if (len % 16) {
         fputc('\n', f);
+    }
     fclose(f);
     return 0;
 }
 
-static int write_component(const char *name,
-                           const uint8_t *data, size_t len)
+static int write_component(const char *name, const uint8_t *data, size_t len)
 {
     size_t name_len = strlen(name);
     char *bin_path = malloc(name_len + 4 + 1);
     char *hex_path = malloc(name_len + 4 + 1);
-    if (!bin_path || !hex_path) {
+    if (bin_path == NULL || hex_path == NULL) {
         free(bin_path);
         free(hex_path);
         return -1;
@@ -82,15 +99,15 @@ static int write_component(const char *name,
 int write_outputs(const char *out_path, int include_keys,
                   const crypto_key *priv, const crypto_key *pub,
                   const uint8_t aes_key[CRYPTO_AES_MAX_KEY_SIZE],
-                  size_t aes_key_len,
-                  const uint8_t iv[CRYPTO_AES_IV_SIZE],
-                  const uint8_t *sig, size_t sig_len,
-                  const uint8_t *enc, size_t enc_len)
+                  size_t aes_key_len, const uint8_t iv[CRYPTO_AES_IV_SIZE],
+                  const uint8_t *sig, size_t sig_len, const uint8_t *enc,
+                  size_t enc_len)
 {
     size_t out_len = strlen(out_path);
     char *hex_path = malloc(out_len + 4 + 1);
-    if (!hex_path)
+    if (hex_path == NULL) {
         return -1;
+    }
     sprintf(hex_path, "%s.hex", out_path);
     if (write_bin_hex_pair(out_path, hex_path, enc, enc_len) != 0) {
         free(hex_path);
@@ -102,18 +119,83 @@ int write_outputs(const char *out_path, int include_keys,
 
     if (include_keys) {
         int ret = 0;
-        if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0)
-            ret = -1;
-        else if (write_component("aes", aes_key, aes_key_len) != 0)
-            ret = -1;
-        else if (write_component("sk", priv->key, priv->key_len) != 0)
-            ret = -1;
-        else if (write_component("pk", pub->key, pub->key_len) != 0)
-            ret = -1;
-        else if (write_component("sig", sig, sig_len) != 0)
-            ret = -1;
-        if (ret != 0)
+        crypto_key privs[2] = {{0}};
+        crypto_key pubs[2] = {{0}};
+        crypto_key priv_ser = {0}, pub_ser = {0};
+        size_t sig_lens[2] = {0};
+        int hybrid = (priv->alg == CRYPTO_ALG_RSA4096_LMS ||
+                      priv->alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
+                      priv->alg == CRYPTO_ALG_LMS_MLDSA87);
+
+        if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0) {
+            goto error;
+        }
+        if (write_component("aes", aes_key, aes_key_len) != 0) {
+            goto error;
+        }
+
+        if (hybrid) {
+            if (crypto_hybrid_export_keypairs(priv->alg, priv, pub, privs,
+                                              pubs) != 0) {
+                goto error;
+            }
+
+            if (crypto_hybrid_get_sig_lens(priv->alg, &sig_lens[0],
+                                           &sig_lens[1]) != 0) {
+                goto error;
+            }
+
+            if (sig_len != sig_lens[0] + sig_lens[1]) {
+                goto error;
+            }
+            if (write_component("sk0", privs[0].key, privs[0].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("sk1", privs[1].key, privs[1].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("pk0", pubs[0].key, pubs[0].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("pk1", pubs[1].key, pubs[1].key_len) != 0) {
+                goto error;
+            }
+            if (write_component("sig0", sig, sig_lens[0]) != 0) {
+                goto error;
+            }
+            if (write_component("sig1", sig + sig_lens[0], sig_lens[1]) != 0) {
+                goto error;
+            }
+        } else {
+            if (crypto_export_keypair(priv->alg, priv, pub, &priv_ser,
+                                      &pub_ser) != 0) {
+                goto error;
+            }
+            if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0) {
+                goto error;
+            }
+            if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0) {
+                goto error;
+            }
+            if (write_component("sig0", sig, sig_len) != 0) {
+                goto error;
+            }
+        }
+        goto cleanup;
+
+    error:
+        ret = -1;
+
+    cleanup:
+        free(privs[0].key);
+        free(privs[1].key);
+        free(pubs[0].key);
+        free(pubs[1].key);
+        free(priv_ser.key);
+        free(pub_ser.key);
+        if (ret != 0) {
             return -1;
+        }
     }
     return 0;
 }

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -242,10 +242,17 @@ static void test_rsa_lms_sign_verify(void **state) {
     assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096_LMS, &priv,
                                  msg, sizeof(msg) - 1,
                                  sig, &sig_len), 0);
-    assert_int_equal(sig_len,
-                     CRYPTO_RSA_SIG_SIZE +
-                     MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                         MBEDTLS_LMOTS_SHA256_N32_W8));
+    size_t len1 = 0;
+    size_t len2 = 0;
+    crypto_alg first = 0;
+    crypto_alg second = 0;
+    assert_int_equal(crypto_hybrid_get_algs(CRYPTO_ALG_RSA4096_LMS,
+                                            &first, &second), 0);
+    assert_int_equal(first, CRYPTO_ALG_RSA4096);
+    assert_int_equal(second, CRYPTO_ALG_LMS);
+    assert_int_equal(crypto_hybrid_get_sig_lens(CRYPTO_ALG_RSA4096_LMS,
+                                                &len1, &len2), 0);
+    assert_int_equal(sig_len, len1 + len2);
     assert_int_equal(crypto_verify(CRYPTO_ALG_RSA4096_LMS, &pub,
                                    msg, sizeof(msg) - 1,
                                    sig, sig_len), 0);
@@ -265,8 +272,17 @@ static void test_rsa_mldsa_sign_verify(void **state) {
     assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096_MLDSA87, &priv,
                                  msg, sizeof(msg) - 1,
                                  sig, &sig_len), 0);
-    assert_int_equal(sig_len,
-                     CRYPTO_RSA_SIG_SIZE + PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES);
+    size_t len1 = 0;
+    size_t len2 = 0;
+    crypto_alg first = 0;
+    crypto_alg second = 0;
+    assert_int_equal(crypto_hybrid_get_algs(CRYPTO_ALG_RSA4096_MLDSA87,
+                                            &first, &second), 0);
+    assert_int_equal(first, CRYPTO_ALG_RSA4096);
+    assert_int_equal(second, CRYPTO_ALG_MLDSA87);
+    assert_int_equal(crypto_hybrid_get_sig_lens(CRYPTO_ALG_RSA4096_MLDSA87,
+                                                &len1, &len2), 0);
+    assert_int_equal(sig_len, len1 + len2);
     assert_int_equal(crypto_verify(CRYPTO_ALG_RSA4096_MLDSA87, &pub,
                                    msg, sizeof(msg) - 1,
                                    sig, sig_len), 0);
@@ -286,10 +302,17 @@ static void test_lms_mldsa_sign_verify(void **state) {
     assert_int_equal(crypto_sign(CRYPTO_ALG_LMS_MLDSA87, &priv,
                                  msg, sizeof(msg) - 1,
                                  sig, &sig_len), 0);
-    assert_int_equal(sig_len,
-                     MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10,
-                                         MBEDTLS_LMOTS_SHA256_N32_W8) +
-                     PQCLEAN_MLDSA87_CLEAN_CRYPTO_BYTES);
+    size_t len1 = 0;
+    size_t len2 = 0;
+    crypto_alg first = 0;
+    crypto_alg second = 0;
+    assert_int_equal(crypto_hybrid_get_algs(CRYPTO_ALG_LMS_MLDSA87,
+                                            &first, &second), 0);
+    assert_int_equal(first, CRYPTO_ALG_LMS);
+    assert_int_equal(second, CRYPTO_ALG_MLDSA87);
+    assert_int_equal(crypto_hybrid_get_sig_lens(CRYPTO_ALG_LMS_MLDSA87,
+                                                &len1, &len2), 0);
+    assert_int_equal(sig_len, len1 + len2);
     assert_int_equal(crypto_verify(CRYPTO_ALG_LMS_MLDSA87, &pub,
                                    msg, sizeof(msg) - 1,
                                    sig, sig_len), 0);
@@ -328,11 +351,7 @@ static void outputs_roundtrip(crypto_alg alg) {
     assert_true(fd != -1);
     close(fd);
 
-    crypto_key priv_ser = {0}, pub_ser = {0};
-    assert_int_equal(crypto_export_keypair(alg, &priv, &pub,
-                                           &priv_ser, &pub_ser), 0);
-
-    assert_int_equal(write_outputs(out_path, 1, &priv_ser, &pub_ser,
+    assert_int_equal(write_outputs(out_path, 1, &priv, &pub,
                                    aes_key, CRYPTO_AES_KEY_BITS_128 / 8,
                                    iv, sig, sig_len, enc, enc_len), 0);
 
@@ -344,14 +363,62 @@ static void outputs_roundtrip(crypto_alg alg) {
     free(tmp);
 
     char path[64];
-    const struct { const char *name; const uint8_t *data; size_t len; } comps[] = {
-        {"aes_iv", iv, CRYPTO_AES_IV_SIZE},
-        {"aes", aes_key, CRYPTO_AES_KEY_BITS_128 / 8},
-        {"sk", priv_ser.key, priv_ser.key_len},
-        {"pk", pub_ser.key, pub_ser.key_len},
-        {"sig", sig, sig_len},
-    };
-    for (size_t i = 0; i < sizeof(comps)/sizeof(comps[0]); i++) {
+    crypto_key priv_ser[2] = {{0}};
+    crypto_key pub_ser[2] = {{0}};
+    size_t key_count = 1;
+    if (alg == CRYPTO_ALG_RSA4096_LMS ||
+        alg == CRYPTO_ALG_RSA4096_MLDSA87 ||
+        alg == CRYPTO_ALG_LMS_MLDSA87) {
+        assert_int_equal(crypto_hybrid_export_keypairs(alg, &priv, &pub,
+                                                      priv_ser, pub_ser), 0);
+        key_count = 2;
+    } else {
+        assert_int_equal(crypto_export_keypair(alg, &priv, &pub,
+                                              &priv_ser[0], &pub_ser[0]), 0);
+    }
+
+    struct { char name[8]; const uint8_t *data; size_t len; } comps[9];
+    size_t comp_idx = 0;
+    strcpy(comps[comp_idx].name, "aes_iv");
+    comps[comp_idx].data = iv;
+    comps[comp_idx].len  = CRYPTO_AES_IV_SIZE;
+    comp_idx++;
+    strcpy(comps[comp_idx].name, "aes");
+    comps[comp_idx].data = aes_key;
+    comps[comp_idx].len  = CRYPTO_AES_KEY_BITS_128 / 8;
+    comp_idx++;
+    for (size_t i = 0; i < key_count; i++) {
+        sprintf(comps[comp_idx].name, "sk%zu", i);
+        comps[comp_idx].data = priv_ser[i].key;
+        comps[comp_idx].len  = priv_ser[i].key_len;
+        comp_idx++;
+    }
+    for (size_t i = 0; i < key_count; i++) {
+        sprintf(comps[comp_idx].name, "pk%zu", i);
+        comps[comp_idx].data = pub_ser[i].key;
+        comps[comp_idx].len  = pub_ser[i].key_len;
+        comp_idx++;
+    }
+    if (key_count == 2) {
+        size_t len1 = 0;
+        size_t len2 = 0;
+        assert_int_equal(crypto_hybrid_get_sig_lens(alg, &len1, &len2), 0);
+        sprintf(comps[comp_idx].name, "sig0");
+        comps[comp_idx].data = sig;
+        comps[comp_idx].len  = len1;
+        comp_idx++;
+        sprintf(comps[comp_idx].name, "sig1");
+        comps[comp_idx].data = sig + len1;
+        comps[comp_idx].len  = len2;
+        comp_idx++;
+    } else {
+        strcpy(comps[comp_idx].name, "sig0");
+        comps[comp_idx].data = sig;
+        comps[comp_idx].len  = sig_len;
+        comp_idx++;
+    }
+
+    for (size_t i = 0; i < comp_idx; i++) {
         sprintf(path, "%s.bin", comps[i].name);
         tmp = NULL;
         len = 0;
@@ -373,8 +440,10 @@ static void outputs_roundtrip(crypto_alg alg) {
 
     free(sig);
     free(enc);
-    free(priv_ser.key);
-    free(pub_ser.key);
+    for (size_t i = 0; i < key_count; i++) {
+        free(priv_ser[i].key);
+        free(pub_ser[i].key);
+    }
     void *shared = (priv.key == pub.key) ? priv.key : NULL;
     crypto_free_key(&priv);
     if (shared)


### PR DESCRIPTION
## Summary
- add `crypto_hybrid_get_sig_lens` to centralize hybrid signature component lengths
- replace duplicated signature length switches in signing, verification, output emission and tests
- introduce `crypto_hybrid_get_algs` to map hybrid algorithms to their component algorithms and refactor callers

## Testing
- `scripts/install_third_party.sh`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b69c07d6d483329cc971837da0cf1f