### PR TITLE
Use Doxygen-style comments for public interfaces

### DIFF
--- a/include/cliopts.h
+++ b/include/cliopts.h
@@ -8,18 +8,26 @@
 extern "C" {
 #endif
 
+/** Parsed command-line parameters. */
 typedef struct {
-    crypto_alg alg;
-    size_t aes_bits;
-    const char *infile;
-    const char *outfile;
-    const char *pk_path;
-    const char *sk_path;
-    const char *aes_key_path;
-    const char *aes_iv_path;
+    crypto_alg alg;           /**< selected signing algorithm */
+    size_t aes_bits;          /**< AES key size in bits */
+    const char *infile;       /**< path to input file */
+    const char *outfile;      /**< path to output file */
+    const char *pk_path;      /**< public key file path */
+    const char *sk_path;      /**< private key file path */
+    const char *aes_key_path; /**< AES key file path */
+    const char *aes_iv_path;  /**< AES IV file path */
 } cli_options;
 
+/**
+ * @brief Parse argc/argv into opts.
+ *
+ * @return 0 on success, -1 on error.
+ */
 int cli_parse_args(int argc, char **argv, cli_options *opts);
+
+/** @brief Print usage information for the program. */
 void cli_usage(const char *prog);
 
 #ifdef __cplusplus

--- a/include/crypto.h
+++ b/include/crypto.h
@@ -8,56 +8,70 @@
 extern "C" {
 #endif
 
-/* AES key sizes in bits */
-#define CRYPTO_AES_KEY_BITS_128 128
-#define CRYPTO_AES_KEY_BITS_192 192
-#define CRYPTO_AES_KEY_BITS_256 256
+/** AES key sizes in bits */
+#define CRYPTO_AES_KEY_BITS_128 128 /**< 128-bit key */
+#define CRYPTO_AES_KEY_BITS_192 192 /**< 192-bit key */
+#define CRYPTO_AES_KEY_BITS_256 256 /**< 256-bit key */
 
-/* Size of the CBC initialization vector in bytes */
+/** Size of the CBC initialization vector in bytes */
 #define CRYPTO_AES_IV_SIZE 16
-/* Maximum AES key size in bytes (AES-256) */
+/** Maximum AES key size in bytes (AES-256) */
 #define CRYPTO_AES_MAX_KEY_SIZE 32
 
-/* Parameters for RSA4096 key generation */
-#define CRYPTO_RSA_BITS 4096       /* modulus size in bits */
-#define CRYPTO_RSA_EXPONENT 65537  /* public exponent */
-/* RSA signature size in bytes for a 4096-bit key */
+/** Parameters for RSA4096 key generation */
+#define CRYPTO_RSA_BITS 4096       /**< modulus size in bits */
+#define CRYPTO_RSA_EXPONENT 65537  /**< public exponent */
+/** RSA signature size in bytes for a 4096-bit key */
 #define CRYPTO_RSA_SIG_SIZE (CRYPTO_RSA_BITS / 8)
 
-/* Output size of SHA-384 in bytes */
+/** Output size of SHA-384 in bytes */
 #define CRYPTO_SHA384_DIGEST_SIZE 48
 
-/* Length of the random seed used to generate LMS keys */
+/** Length of the random seed used to generate LMS keys */
 #define CRYPTO_LMS_SEED_SIZE 32
 
-/* Buffer large enough to hold any supported signature */
+/** Buffer large enough to hold any supported signature */
 #define CRYPTO_MAX_SIG_SIZE 10240
 
+/** Supported cryptographic algorithm identifiers. */
 typedef enum {
-    CRYPTO_ALG_RSA4096,
-    CRYPTO_ALG_LMS,
-    CRYPTO_ALG_MLDSA87,
-    CRYPTO_ALG_RSA4096_LMS,
-    CRYPTO_ALG_RSA4096_MLDSA87,
-    CRYPTO_ALG_LMS_MLDSA87
+    CRYPTO_ALG_RSA4096,         /**< RSA with 4096-bit modulus */
+    CRYPTO_ALG_LMS,             /**< Leighton-Micali Signature scheme */
+    CRYPTO_ALG_MLDSA87,         /**< ML-DSA with 87-byte signatures */
+    CRYPTO_ALG_RSA4096_LMS,     /**< Hybrid RSA-4096 and LMS */
+    CRYPTO_ALG_RSA4096_MLDSA87, /**< Hybrid RSA-4096 and ML-DSA87 */
+    CRYPTO_ALG_LMS_MLDSA87      /**< Hybrid LMS and ML-DSA87 */
 } crypto_alg;
 
+/** Generic wrapper for algorithm-specific key material. */
 typedef struct {
-    crypto_alg alg;
-    void *key;
-    size_t key_len;
+    crypto_alg alg; /**< algorithm this key is for */
+    void *key;      /**< pointer to algorithm-specific key data */
+    size_t key_len; /**< length of key data in bytes */
 } crypto_key;
 
+/** @brief Generate a key pair for the specified algorithm. */
 int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub);
+
+/**
+ * @brief Load an existing key pair from disk or generate a new one if paths are NULL.
+ */
 int crypto_load_keypair(crypto_alg alg, const char *priv_path, const char *pub_path,
                         crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Initialize an AES key and IV from files or randomly. */
 int crypto_init_aes(size_t bits, const char *key_path, const char *iv_path,
                     uint8_t *key_out, uint8_t iv_out[CRYPTO_AES_IV_SIZE]);
+
+/** @brief Sign the input message using the given private key. */
 int crypto_sign(crypto_alg alg, const crypto_key *priv, const uint8_t *msg, size_t msg_len,
                 uint8_t *sig, size_t *sig_len);
+
+/** @brief Verify a signature against the input message and public key. */
 int crypto_verify(crypto_alg alg, const crypto_key *pub, const uint8_t *msg, size_t msg_len,
                   const uint8_t *sig, size_t sig_len);
 
+/** @brief Encrypt/decrypt using AES in CBC mode with PKCS#7 padding. */
 int crypto_encrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t iv[CRYPTO_AES_IV_SIZE],
                           const uint8_t *in, size_t len, uint8_t *out,
@@ -67,25 +81,32 @@ int crypto_decrypt_aescbc(const uint8_t *key, size_t bits,
                           const uint8_t *in, size_t len, uint8_t *out,
                           size_t *out_len);
 
+/** @brief Compute SHA-384 over the input buffer. */
 int crypto_sha384(const uint8_t *in, size_t len,
                   uint8_t out[CRYPTO_SHA384_DIGEST_SIZE]);
 
+/** @brief Serialize a key pair to simple memory buffers. */
 int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
                           const crypto_key *pub, crypto_key *out_priv,
                           crypto_key *out_pub);
 
+/** @brief Export both components of a hybrid key pair into two arrays. */
 int crypto_hybrid_export_keypairs(crypto_alg alg, const crypto_key *priv,
                                   const crypto_key *pub,
                                   crypto_key out_priv[2],
                                   crypto_key out_pub[2]);
 
+/** @brief Return non-zero if alg represents a hybrid scheme. */
 int crypto_is_hybrid_alg(crypto_alg alg);
 
+/** @brief Determine the underlying algorithms for a hybrid scheme. */
 int crypto_hybrid_get_algs(crypto_alg alg, crypto_alg *first,
                            crypto_alg *second);
 
+/** @brief Get signature lengths for a hybrid algorithm. */
 int crypto_hybrid_get_sig_lens(crypto_alg alg, size_t *len1, size_t *len2);
 
+/** @brief Release any resources held by a key. */
 void crypto_free_key(crypto_key *key);
 
 #ifdef __cplusplus

--- a/include/lms.h
+++ b/include/lms.h
@@ -4,16 +4,27 @@
 #include "crypto.h"
 #include <mbedtls/ctr_drbg.h>
 
+/** @brief Generate an LMS key pair using the provided DRBG. */
 int lms_keygen(mbedtls_ctr_drbg_context *drbg, crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Load an LMS key pair from files; currently always generates a fresh pair. */
 int lms_load_keypair(const char *priv_path, const char *pub_path,
                      crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Sign a message with an LMS private key. */
 int lms_sign(mbedtls_ctr_drbg_context *drbg, const crypto_key *priv,
              const uint8_t *msg, size_t msg_len,
              uint8_t *sig, size_t *sig_len);
+
+/** @brief Verify an LMS signature. */
 int lms_verify(const crypto_key *pub, const uint8_t *msg, size_t msg_len,
                const uint8_t *sig, size_t sig_len);
+
+/** @brief Serialize an LMS key pair. */
 int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
                        crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Release resources associated with an LMS key. */
 void lms_free_key(crypto_key *key);
 
 #endif /* LMS_H */

--- a/include/mldsa.h
+++ b/include/mldsa.h
@@ -4,15 +4,26 @@
 #include "crypto.h"
 #include "api.h"
 
+/** @brief Generate an ML-DSA key pair. */
 int mldsa_keygen(crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Load an ML-DSA key pair from the given files. */
 int mldsa_load_keypair(const char *priv_path, const char *pub_path,
                        crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Produce an ML-DSA signature. */
 int mldsa_sign(const crypto_key *priv, const uint8_t *msg, size_t msg_len,
                uint8_t *sig, size_t *sig_len);
+
+/** @brief Verify an ML-DSA signature. */
 int mldsa_verify(const crypto_key *pub, const uint8_t *msg, size_t msg_len,
                  const uint8_t *sig, size_t sig_len);
+
+/** @brief Serialize an ML-DSA key pair. */
 int mldsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
                          crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Release resources for an ML-DSA key. */
 void mldsa_free_key(crypto_key *key);
 
 #endif /* MLDSA_H */

--- a/include/rsa.h
+++ b/include/rsa.h
@@ -4,16 +4,27 @@
 #include "crypto.h"
 #include <mbedtls/ctr_drbg.h>
 
+/** @brief Generate an RSA-4096 key pair using the provided DRBG. */
 int rsa_keygen(mbedtls_ctr_drbg_context *drbg, crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Load an RSA key pair from files. */
 int rsa_load_keypair(const char *priv_path, const char *pub_path,
                      crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Produce an RSA signature. */
 int rsa_sign(mbedtls_ctr_drbg_context *drbg, const crypto_key *priv,
              const uint8_t *msg, size_t msg_len,
              uint8_t *sig, size_t *sig_len);
+
+/** @brief Verify an RSA signature. */
 int rsa_verify(const crypto_key *pub, const uint8_t *msg, size_t msg_len,
                const uint8_t *sig, size_t sig_len);
+
+/** @brief Serialize an RSA key pair. */
 int rsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
                        crypto_key *out_priv, crypto_key *out_pub);
+
+/** @brief Release resources associated with an RSA key. */
 void rsa_free_key(crypto_key *key);
 
 #endif /* RSA_H */

--- a/include/util.h
+++ b/include/util.h
@@ -5,13 +5,17 @@
 #include <stdint.h>
 #include "crypto.h"
 
-/* Read the entire file at path into a newly allocated buffer.
- * On success, *buf will point to the allocated data and *len contains
- * the number of bytes read. The caller is responsible for freeing *buf.
- * Returns 0 on success, -1 on failure.
+/**
+ * @brief Read the entire file at path into a newly allocated buffer.
+ *
+ * On success, @p *buf will point to the allocated data and @p *len contains
+ * the number of bytes read. The caller is responsible for freeing @p *buf.
+ *
+ * @return 0 on success, -1 on failure.
  */
 int read_file(const char *path, uint8_t **buf, size_t *len);
 
+/** @brief Write encrypted data, signature, and optional keys to output files. */
 int write_outputs(const char *out_path, int include_keys,
                   const crypto_key *priv, const crypto_key *pub,
                   const uint8_t aes_key[CRYPTO_AES_MAX_KEY_SIZE],

--- a/libs/mbedtls/PLACEHOLDER
+++ b/libs/mbedtls/PLACEHOLDER
@@ -1,1 +1,0 @@
-Placeholder for mbedtls v3.6.0

--- a/libs/pqclean/PLACEHOLDER
+++ b/libs/pqclean/PLACEHOLDER
@@ -1,1 +1,0 @@
-Placeholder for pqclean commit 448c71a8

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -13,13 +13,15 @@
 #include <mbedtls/md.h>
 #include <mbedtls/lms.h>
 
+/** Holds key material for algorithms composed of two independent schemes. */
 typedef struct {
-    crypto_key first_priv;
-    crypto_key first_pub;
-    crypto_key second_priv;
-    crypto_key second_pub;
+    crypto_key first_priv;  /**< first private key */
+    crypto_key first_pub;   /**< first public key */
+    crypto_key second_priv; /**< second private key */
+    crypto_key second_pub;  /**< second public key */
 } hybrid_pair;
 
+/** Signature length for the LMS parameter set used. */
 #define LMS_SIG_LEN \
     MBEDTLS_LMS_SIG_LEN(MBEDTLS_LMS_SHA256_M32_H10, MBEDTLS_LMOTS_SHA256_N32_W8)
 

--- a/src/lms.c
+++ b/src/lms.c
@@ -4,9 +4,10 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/lms.h>
 
+/** Container for an LMS private/public key pair. */
 typedef struct {
-    mbedtls_lms_private_t priv;
-    mbedtls_lms_public_t pub;
+    mbedtls_lms_private_t priv; /**< private key */
+    mbedtls_lms_public_t pub;   /**< corresponding public key */
 } lms_pair;
 
 static int rng_callback(void *ctx, unsigned char *out, size_t len) {

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -6,6 +6,7 @@
 #include <mbedtls/md.h>
 #include "util.h"
 
+/** Maximum size of a DER-encoded RSA key we expect to handle. */
 #define RSA_DER_MAX_LEN 4096
 
 static int rng_callback(void *ctx, unsigned char *out, size_t len) {

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 200809L
+#define _POSIX_C_SOURCE 200809L /**< for mkstemp and related functions */
 #include "crypto.h"
 #include "util.h"
 #include <stdarg.h>
@@ -14,7 +14,7 @@
 #include <unistd.h>
 #include "api.h"
 
-/* Compute SHA-384 of 'abc' and compare against known vector. */
+/** Compute SHA-384 of 'abc' and compare against known vector. */
 static void test_sha384(void **state) {
     (void)state;
     uint8_t out[CRYPTO_SHA384_DIGEST_SIZE];
@@ -30,7 +30,7 @@ static void test_sha384(void **state) {
     assert_memory_equal(out, expected, CRYPTO_SHA384_DIGEST_SIZE);
 }
 
-/* Encrypt and decrypt a block-aligned payload with AES-CBC. */
+/** Encrypt and decrypt a block-aligned payload with AES-CBC. */
 static void test_aes_cbc(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -52,7 +52,7 @@ static void test_aes_cbc(void **state) {
     assert_memory_equal(dec, plaintext, 32);
 }
 
-/* Encrypt and decrypt data whose length is not a multiple of the block size. */
+/** Encrypt and decrypt data whose length is not a multiple of the block size. */
 static void test_aes_cbc_unaligned(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -74,7 +74,7 @@ static void test_aes_cbc_unaligned(void **state) {
     assert_memory_equal(dec, plaintext, sizeof(plaintext) - 1);
 }
 
-/* Handle AES-CBC operations on an empty plaintext. */
+/** Handle AES-CBC operations on an empty plaintext. */
 static void test_aes_cbc_empty(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -97,6 +97,7 @@ static void test_aes_cbc_empty(void **state) {
 #include <stdio.h>
 #include <unistd.h>
 
+/** Temporary file paths for AES key/IV used in tests. */
 struct aes_paths {
     char key_path[sizeof("/tmp/keyXXXXXX")];
     char iv_path[sizeof("/tmp/ivXXXXXX")];
@@ -166,7 +167,7 @@ static void test_aes_serialize_256(void **state) {
     aes_roundtrip(CRYPTO_AES_KEY_BITS_256, (const struct aes_paths *)*state);
 }
 
-/* Generate RSA key pair and verify signing round-trip. */
+/** Generate RSA key pair and verify signing round-trip. */
 static void test_rsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -188,7 +189,7 @@ static void test_rsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
-/* Generate LMS key pair and verify signing round-trip. */
+/** Generate LMS key pair and verify signing round-trip. */
 static void test_lms_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -212,7 +213,7 @@ static void test_lms_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
-/* Ensure LMS q_next_usable_key is preserved across serialization. */
+/** Ensure LMS q_next_usable_key is preserved across serialization. */
 static void test_lms_q_next_usable_key(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -267,7 +268,7 @@ static void test_lms_q_next_usable_key(void **state) {
     crypto_free_key(&pub);
 }
 
-/* Generate ML-DSA key pair and verify signing round-trip. */
+/** Generate ML-DSA key pair and verify signing round-trip. */
 static void test_mldsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -287,7 +288,7 @@ static void test_mldsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
-/* Verify combined RSA+LMS hybrid signature workflow. */
+/** Verify combined RSA+LMS hybrid signature workflow. */
 static void test_rsa_lms_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -317,7 +318,7 @@ static void test_rsa_lms_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
-/* Verify combined RSA+ML-DSA hybrid signature workflow. */
+/** Verify combined RSA+ML-DSA hybrid signature workflow. */
 static void test_rsa_mldsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -347,7 +348,7 @@ static void test_rsa_mldsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
-/* Verify combined LMS+ML-DSA hybrid signature workflow. */
+/** Verify combined LMS+ML-DSA hybrid signature workflow. */
 static void test_lms_mldsa_sign_verify(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
@@ -535,7 +536,7 @@ static void test_lms_mldsa_outputs(void **state) {
     outputs_roundtrip(CRYPTO_ALG_LMS_MLDSA87);
 }
 
-/* Reject invalid parameters to AES initialisation routine. */
+/** Reject invalid parameters to AES initialisation routine. */
 static void test_crypto_init_aes_invalid(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_MAX_KEY_SIZE];
@@ -545,7 +546,7 @@ static void test_crypto_init_aes_invalid(void **state) {
     assert_int_equal(crypto_init_aes(CRYPTO_AES_KEY_BITS_128, NULL, NULL, key, NULL), -1);
 }
 
-/* Reject invalid arguments to SHA-384 helper. */
+/** Reject invalid arguments to SHA-384 helper. */
 static void test_crypto_sha384_invalid(void **state) {
     (void)state;
     uint8_t out[CRYPTO_SHA384_DIGEST_SIZE];
@@ -553,7 +554,7 @@ static void test_crypto_sha384_invalid(void **state) {
     assert_int_equal(crypto_sha384((const uint8_t *)"a", 1, NULL), -1);
 }
 
-/* Reject invalid parameters to AES-CBC encryption. */
+/** Reject invalid parameters to AES-CBC encryption. */
 static void test_crypto_encrypt_invalid(void **state) {
     (void)state;
     uint8_t key[CRYPTO_AES_IV_SIZE] = {0};
@@ -578,7 +579,7 @@ static void test_crypto_encrypt_invalid(void **state) {
                                            NULL), -1);
 }
 
-/* Reject improper arguments to signing function. */
+/** Reject improper arguments to signing function. */
 static void test_crypto_sign_invalid(void **state) {
     (void)state;
     crypto_key priv = {0};
@@ -590,7 +591,7 @@ static void test_crypto_sign_invalid(void **state) {
     assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096, &priv, (uint8_t *)"a", 1, sig, NULL), -1);
 }
 
-/* Reject improper arguments to signature verification function. */
+/** Reject improper arguments to signature verification function. */
 static void test_crypto_verify_invalid(void **state) {
     (void)state;
     crypto_key pub = {0};


### PR DESCRIPTION
## Summary
- convert CLI option structure and parsing helpers to Doxygen comments
- switch crypto macros, enums, and key helpers to Doxygen style
- document tests and internal structs with Doxygen annotations

## Testing
- `scripts/install_third_party.sh`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68be1c36bfdc83329bada2cc4a950cfe