### PR TITLE
Generate missing key material automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ encsigtool: libcrypto.a $(TOOL_OBJ)
 $(TEST_BIN): $(MBEDTLS_LIBS) $(PQ_LIB) libcrypto.a $(TEST_OBJ)
 	$(CC) $(CFLAGS) -o $@ $(TEST_OBJ) -Wl,--start-group libcrypto.a $(LDFLAGS) -Wl,--end-group -lcmocka
 
-test: $(MBEDTLS_LIBS) $(PQ_LIB) $(TEST_BIN)
+test: $(MBEDTLS_LIBS) $(PQ_LIB) encsigtool $(TEST_BIN)
 	$(TEST_BIN)
 
 debug: CFLAGS += -g -O0


### PR DESCRIPTION
## Summary
- Allow encsigtool to generate missing key material when only partial paths are provided
- Add integration tests for automatic keypair and AES key generation
- Ensure test target builds the tool required by the new tests

## Testing
- `scripts/install_third_party.sh`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68be4a32ace48332a33dba8a38b9be24