### PR TITLE
Support hybrid key import

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -53,13 +53,25 @@ typedef enum {
 } crypto_alg;
 
 /**
+ * enum crypto_key_type - distinguishes public and private keys
+ * @CRYPTO_KEY_TYPE_PRIVATE: private key
+ * @CRYPTO_KEY_TYPE_PUBLIC: public key
+ */
+typedef enum {
+    CRYPTO_KEY_TYPE_PRIVATE,
+    CRYPTO_KEY_TYPE_PUBLIC,
+} crypto_key_type;
+
+/**
  * struct crypto_key - generic wrapper for algorithm-specific key material
  * @alg:     algorithm this key is for
+ * @type:    whether the key is private or public
  * @key:     pointer to algorithm-specific key data
  * @key_len: length of key data in bytes
  */
 typedef struct {
     crypto_alg alg;
+    crypto_key_type type;
     void *key;
     size_t key_len;
 } crypto_key;

--- a/src/cliopts.c
+++ b/src/cliopts.c
@@ -11,8 +11,10 @@ void cli_usage(const char *prog)
             prog);
     fprintf(stderr, "  -a <alg>            signing algorithm: rsa,lms,mldsa87,rsa-lms,rsa-mldsa87,lms-mldsa87\n");
     fprintf(stderr, "  -b <bits>           AES key bits: 128,192,256\n");
-    fprintf(stderr, "  --pk-path <file>    public key file\n");
-    fprintf(stderr, "  --sk-path <file>    private key file\n");
+    fprintf(stderr,
+            "  --pk-path <file[,file]>    public key file(s)\n");
+    fprintf(stderr,
+            "  --sk-path <file[,file]>    private key file(s)\n");
     fprintf(stderr, "  --aes-key-path <f>  AES key file\n");
     fprintf(stderr, "  --aes-iv <f>        AES IV file (optional)\n");
     fprintf(stderr, "  -i <file>           input file\n");

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -159,6 +159,8 @@ int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub)
         }
         out_priv->alg     = alg;
         out_pub->alg      = alg;
+        out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
+        out_pub->type     = CRYPTO_KEY_TYPE_PUBLIC;
         out_priv->key     = pair;
         out_pub->key      = pair;
         out_priv->key_len = sizeof(*pair);
@@ -220,10 +222,12 @@ static int load_hybrid_keypair(crypto_alg alg, const char *priv_path, const char
         return -1;
     }
 
-    out_priv->alg = alg;
-    out_pub->alg  = alg;
-    out_priv->key = pair;
-    out_pub->key  = pair;
+    out_priv->alg  = alg;
+    out_pub->alg   = alg;
+    out_priv->type = CRYPTO_KEY_TYPE_PRIVATE;
+    out_pub->type  = CRYPTO_KEY_TYPE_PUBLIC;
+    out_priv->key  = pair;
+    out_pub->key   = pair;
     out_priv->key_len = sizeof(*pair);
     out_pub->key_len  = sizeof(*pair);
     return 0;
@@ -642,6 +646,11 @@ void crypto_free_key(crypto_key *key)
     } else if (key->alg == CRYPTO_ALG_MLDSA87) {
         mldsa_free_key(key);
     } else if (crypto_is_hybrid_alg(key->alg)) {
+        if (key->type == CRYPTO_KEY_TYPE_PUBLIC) {
+            key->key     = NULL;
+            key->key_len = 0;
+            return;
+        }
         hybrid_pair *pair = key->key;
         crypto_free_key(&pair->first_priv);
         crypto_free_key(&pair->first_pub);

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -149,22 +149,10 @@ int crypto_keygen(crypto_alg alg, crypto_key *out_priv, crypto_key *out_pub)
         }
         if (crypto_keygen(first, &pair->first_priv, &pair->first_pub) != 0 ||
             crypto_keygen(second, &pair->second_priv, &pair->second_pub) != 0) {
-            int first_shared  = pair->first_pub.key == pair->first_priv.key;
-            int second_shared = pair->second_pub.key == pair->second_priv.key;
             crypto_free_key(&pair->first_priv);
-            if (first_shared) {
-                pair->first_pub.key = NULL;
-                pair->first_pub.key_len = 0;
-            } else {
-                crypto_free_key(&pair->first_pub);
-            }
+            crypto_free_key(&pair->first_pub);
             crypto_free_key(&pair->second_priv);
-            if (second_shared) {
-                pair->second_pub.key = NULL;
-                pair->second_pub.key_len = 0;
-            } else {
-                crypto_free_key(&pair->second_pub);
-            }
+            crypto_free_key(&pair->second_pub);
             free(pair);
             ret = -1;
             goto cleanup;
@@ -224,22 +212,10 @@ static int load_hybrid_keypair(crypto_alg alg, const char *priv_path, const char
     if (crypto_hybrid_get_algs(alg, &first, &second) != 0 ||
         crypto_load_keypair(first, priv0, pub0, &pair->first_priv, &pair->first_pub) != 0 ||
         crypto_load_keypair(second, priv1, pub1, &pair->second_priv, &pair->second_pub) != 0) {
-        int first_shared  = pair->first_pub.key == pair->first_priv.key;
-        int second_shared = pair->second_pub.key == pair->second_priv.key;
         crypto_free_key(&pair->first_priv);
-        if (first_shared) {
-            pair->first_pub.key = NULL;
-            pair->first_pub.key_len = 0;
-        } else {
-            crypto_free_key(&pair->first_pub);
-        }
+        crypto_free_key(&pair->first_pub);
         crypto_free_key(&pair->second_priv);
-        if (second_shared) {
-            pair->second_pub.key = NULL;
-            pair->second_pub.key_len = 0;
-        } else {
-            crypto_free_key(&pair->second_pub);
-        }
+        crypto_free_key(&pair->second_pub);
         free(pair);
         return -1;
     }
@@ -667,22 +643,10 @@ void crypto_free_key(crypto_key *key)
         mldsa_free_key(key);
     } else if (crypto_is_hybrid_alg(key->alg)) {
         hybrid_pair *pair = key->key;
-        int first_shared  = pair->first_pub.key == pair->first_priv.key;
-        int second_shared = pair->second_pub.key == pair->second_priv.key;
         crypto_free_key(&pair->first_priv);
-        if (first_shared) {
-            pair->first_pub.key = NULL;
-            pair->first_pub.key_len = 0;
-        } else {
-            crypto_free_key(&pair->first_pub);
-        }
+        crypto_free_key(&pair->first_pub);
         crypto_free_key(&pair->second_priv);
-        if (second_shared) {
-            pair->second_pub.key = NULL;
-            pair->second_pub.key_len = 0;
-        } else {
-            crypto_free_key(&pair->second_pub);
-        }
+        crypto_free_key(&pair->second_pub);
         free(pair);
         key->key     = NULL;
         key->key_len = 0;

--- a/src/lms.c
+++ b/src/lms.c
@@ -4,16 +4,6 @@
 #include <mbedtls/entropy.h>
 #include <mbedtls/lms.h>
 
-/**
- * struct lms_pair - container for an LMS private/public key pair
- * @priv: private key
- * @pub: corresponding public key
- */
-typedef struct {
-    mbedtls_lms_private_t priv;
-    mbedtls_lms_public_t pub;
-} lms_pair;
-
 static int rng_callback(void *ctx, unsigned char *out, size_t len) {
     return mbedtls_ctr_drbg_random((mbedtls_ctr_drbg_context *)ctx, out, len);
 }
@@ -23,31 +13,34 @@ int lms_keygen(mbedtls_ctr_drbg_context *drbg,
     if (!drbg || !out_priv || !out_pub) {
         return -1;
     }
-    lms_pair *pair = calloc(1, sizeof(*pair));
-    if (!pair) {
+    mbedtls_lms_private_t *pr = calloc(1, sizeof(*pr));
+    mbedtls_lms_public_t *pu  = calloc(1, sizeof(*pu));
+    if (!pr || !pu) {
+        free(pr);
+        free(pu);
         return -1;
     }
-    mbedtls_lms_private_init(&pair->priv);
-    mbedtls_lms_public_init(&pair->pub);
+    mbedtls_lms_private_init(pr);
+    mbedtls_lms_public_init(pu);
     unsigned char seed[CRYPTO_LMS_SEED_SIZE];
     if (mbedtls_ctr_drbg_random(drbg, seed, sizeof(seed)) != 0 ||
-        mbedtls_lms_generate_private_key(&pair->priv,
-                                         MBEDTLS_LMS_SHA256_M32_H10,
+        mbedtls_lms_generate_private_key(pr, MBEDTLS_LMS_SHA256_M32_H10,
                                          MBEDTLS_LMOTS_SHA256_N32_W8,
                                          rng_callback, drbg,
                                          seed, sizeof(seed)) != 0 ||
-        mbedtls_lms_calculate_public_key(&pair->pub, &pair->priv) != 0) {
-        mbedtls_lms_private_free(&pair->priv);
-        mbedtls_lms_public_free(&pair->pub);
-        free(pair);
+        mbedtls_lms_calculate_public_key(pu, pr) != 0) {
+        mbedtls_lms_private_free(pr);
+        mbedtls_lms_public_free(pu);
+        free(pr);
+        free(pu);
         return -1;
     }
     out_priv->alg     = CRYPTO_ALG_LMS;
     out_pub->alg      = CRYPTO_ALG_LMS;
-    out_priv->key     = pair;
-    out_pub->key      = pair;
-    out_priv->key_len = sizeof(*pair);
-    out_pub->key_len  = sizeof(*pair);
+    out_priv->key     = pr;
+    out_pub->key      = pu;
+    out_priv->key_len = sizeof(*pr);
+    out_pub->key_len  = sizeof(*pu);
     return 0;
 }
 
@@ -75,9 +68,9 @@ int lms_sign(mbedtls_ctr_drbg_context *drbg, const crypto_key *priv,
         priv->alg != CRYPTO_ALG_LMS) {
         return -1;
     }
-    lms_pair *pair = priv->key;
+    mbedtls_lms_private_t *pr = priv->key;
     size_t olen = 0;
-    if (mbedtls_lms_sign(&pair->priv, rng_callback, drbg,
+    if (mbedtls_lms_sign(pr, rng_callback, drbg,
                           msg, msg_len, sig, *sig_len, &olen) != 0) {
         return -1;
     }
@@ -90,8 +83,8 @@ int lms_verify(const crypto_key *pub, const uint8_t *msg, size_t msg_len,
     if (!pub || !msg || !sig || pub->alg != CRYPTO_ALG_LMS) {
         return -1;
     }
-    lms_pair *pair = pub->key;
-    if (mbedtls_lms_verify(&pair->pub, msg, msg_len, sig, sig_len) != 0) {
+    mbedtls_lms_public_t *pu = pub->key;
+    if (mbedtls_lms_verify(pu, msg, msg_len, sig, sig_len) != 0) {
         return -1;
     }
     return 0;
@@ -102,8 +95,8 @@ int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
     if (!priv || !pub || !out_priv || !out_pub) {
         return -1;
     }
-    const lms_pair *pair = priv->key;
-    const mbedtls_lms_private_t *pr = &pair->priv;
+    const mbedtls_lms_private_t *pr = priv->key;
+    const mbedtls_lms_public_t *pu = pub->key;
     size_t count = 1u << MBEDTLS_LMS_H_TREE_HEIGHT(
         pr->MBEDTLS_PRIVATE(params).MBEDTLS_PRIVATE(type));
     size_t priv_size =
@@ -143,7 +136,7 @@ int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
         return -1;
     }
     size_t olen = 0;
-    if (mbedtls_lms_export_public_key(&pair->pub, pub_buf, pub_len,
+    if (mbedtls_lms_export_public_key(pu, pub_buf, pub_len,
                                       &olen) != 0 || olen != pub_len) {
         free(pbuf);
         free(pub_buf);
@@ -159,10 +152,12 @@ void lms_free_key(crypto_key *key) {
     if (!key || key->alg != CRYPTO_ALG_LMS || !key->key) {
         return;
     }
-    lms_pair *pair = key->key;
-    mbedtls_lms_private_free(&pair->priv);
-    mbedtls_lms_public_free(&pair->pub);
-    free(pair);
+    if (key->key_len == sizeof(mbedtls_lms_private_t)) {
+        mbedtls_lms_private_free((mbedtls_lms_private_t *)key->key);
+    } else if (key->key_len == sizeof(mbedtls_lms_public_t)) {
+        mbedtls_lms_public_free((mbedtls_lms_public_t *)key->key);
+    }
+    free(key->key);
     key->key     = NULL;
     key->key_len = 0;
 }

--- a/src/lms.c
+++ b/src/lms.c
@@ -37,6 +37,8 @@ int lms_keygen(mbedtls_ctr_drbg_context *drbg,
     }
     out_priv->alg     = CRYPTO_ALG_LMS;
     out_pub->alg      = CRYPTO_ALG_LMS;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
+    out_pub->type     = CRYPTO_KEY_TYPE_PUBLIC;
     out_priv->key     = pr;
     out_pub->key      = pu;
     out_priv->key_len = sizeof(*pr);
@@ -127,6 +129,7 @@ int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
     out_priv->key     = pbuf;
     out_priv->key_len = priv_size;
     out_priv->alg     = CRYPTO_ALG_LMS;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
 
     size_t pub_len = MBEDTLS_LMS_PUBLIC_KEY_LEN(
         pr->MBEDTLS_PRIVATE(params).MBEDTLS_PRIVATE(type));
@@ -145,6 +148,7 @@ int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
     out_pub->key     = pub_buf;
     out_pub->key_len = pub_len;
     out_pub->alg     = CRYPTO_ALG_LMS;
+    out_pub->type    = CRYPTO_KEY_TYPE_PUBLIC;
     return 0;
 }
 
@@ -152,9 +156,9 @@ void lms_free_key(crypto_key *key) {
     if (!key || key->alg != CRYPTO_ALG_LMS || !key->key) {
         return;
     }
-    if (key->key_len == sizeof(mbedtls_lms_private_t)) {
+    if (key->type == CRYPTO_KEY_TYPE_PRIVATE) {
         mbedtls_lms_private_free((mbedtls_lms_private_t *)key->key);
-    } else if (key->key_len == sizeof(mbedtls_lms_public_t)) {
+    } else if (key->type == CRYPTO_KEY_TYPE_PUBLIC) {
         mbedtls_lms_public_free((mbedtls_lms_public_t *)key->key);
     }
     free(key->key);

--- a/src/main.c
+++ b/src/main.c
@@ -93,7 +93,8 @@ cleanup:
     free(buf);
     free(sig);
     free(enc);
-    crypto_free_key(&priv); /* pub shares context */
+    crypto_free_key(&priv);
+    crypto_free_key(&pub);
     return ret;
 }
 

--- a/src/mldsa.c
+++ b/src/mldsa.c
@@ -21,6 +21,8 @@ int mldsa_keygen(crypto_key *out_priv, crypto_key *out_pub) {
     }
     out_pub->alg      = CRYPTO_ALG_MLDSA87;
     out_priv->alg     = CRYPTO_ALG_MLDSA87;
+    out_pub->type     = CRYPTO_KEY_TYPE_PUBLIC;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
     out_pub->key      = pk;
     out_pub->key_len  = PQCLEAN_MLDSA87_CLEAN_CRYPTO_PUBLICKEYBYTES;
     out_priv->key     = sk;
@@ -48,6 +50,8 @@ int mldsa_load_keypair(const char *priv_path, const char *pub_path,
     }
     out_priv->alg     = CRYPTO_ALG_MLDSA87;
     out_pub->alg      = CRYPTO_ALG_MLDSA87;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
+    out_pub->type     = CRYPTO_KEY_TYPE_PUBLIC;
     out_priv->key     = priv_buf;
     out_priv->key_len = priv_len;
     out_pub->key      = pub_buf;
@@ -100,8 +104,10 @@ int mldsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
     }
     memcpy(out_priv->key, priv->key, priv->key_len);
     memcpy(out_pub->key, pub->key, pub->key_len);
-    out_priv->alg = CRYPTO_ALG_MLDSA87;
-    out_pub->alg  = CRYPTO_ALG_MLDSA87;
+    out_priv->alg  = CRYPTO_ALG_MLDSA87;
+    out_pub->alg   = CRYPTO_ALG_MLDSA87;
+    out_priv->type = CRYPTO_KEY_TYPE_PRIVATE;
+    out_pub->type  = CRYPTO_KEY_TYPE_PUBLIC;
     return 0;
 }
 

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -50,6 +50,8 @@ int rsa_keygen(mbedtls_ctr_drbg_context *drbg, crypto_key *out_priv, crypto_key 
     }
     out_priv->alg     = CRYPTO_ALG_RSA4096;
     out_pub->alg      = CRYPTO_ALG_RSA4096;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
+    out_pub->type     = CRYPTO_KEY_TYPE_PUBLIC;
     out_priv->key     = priv;
     out_pub->key      = pub;
     out_priv->key_len = sizeof(*priv);
@@ -94,6 +96,8 @@ int rsa_load_keypair(const char *priv_path, const char *pub_path,
     free(pub_buf);
     out_priv->alg     = CRYPTO_ALG_RSA4096;
     out_pub->alg      = CRYPTO_ALG_RSA4096;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
+    out_pub->type     = CRYPTO_KEY_TYPE_PUBLIC;
     out_priv->key     = priv;
     out_pub->key      = pub;
     out_priv->key_len = sizeof(*priv);
@@ -157,6 +161,7 @@ int rsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
     memcpy(out_priv->key, buf + sizeof(buf) - len, len);
     out_priv->key_len = len;
     out_priv->alg     = CRYPTO_ALG_RSA4096;
+    out_priv->type    = CRYPTO_KEY_TYPE_PRIVATE;
 
     len = mbedtls_pk_write_pubkey_der(pk, buf, sizeof(buf));
     if (len <= 0) {
@@ -171,6 +176,7 @@ int rsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
     memcpy(out_pub->key, buf + sizeof(buf) - len, len);
     out_pub->key_len = len;
     out_pub->alg     = CRYPTO_ALG_RSA4096;
+    out_pub->type    = CRYPTO_KEY_TYPE_PUBLIC;
     return 0;
 }
 

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -17,27 +17,43 @@ int rsa_keygen(mbedtls_ctr_drbg_context *drbg, crypto_key *out_priv, crypto_key 
     if (!drbg || !out_priv || !out_pub) {
         return -1;
     }
-    mbedtls_pk_context *pk = calloc(1, sizeof(*pk));
-    if (!pk) {
+    mbedtls_pk_context *priv = calloc(1, sizeof(*priv));
+    mbedtls_pk_context *pub  = calloc(1, sizeof(*pub));
+    if (!priv || !pub) {
+        free(priv);
+        free(pub);
         return -1;
     }
-    mbedtls_pk_init(pk);
-    if (mbedtls_pk_setup(pk, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) != 0) {
-        free(pk);
+    mbedtls_pk_init(priv);
+    mbedtls_pk_init(pub);
+    if (mbedtls_pk_setup(priv, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) != 0) {
+        free(priv);
+        free(pub);
         return -1;
     }
-    if (mbedtls_rsa_gen_key(mbedtls_pk_rsa(*pk), rng_callback, drbg,
+    if (mbedtls_rsa_gen_key(mbedtls_pk_rsa(*priv), rng_callback, drbg,
                             CRYPTO_RSA_BITS, CRYPTO_RSA_EXPONENT) != 0) {
-        mbedtls_pk_free(pk);
-        free(pk);
+        mbedtls_pk_free(priv);
+        free(priv);
+        free(pub);
+        return -1;
+    }
+    unsigned char buf[RSA_DER_MAX_LEN];
+    int len = mbedtls_pk_write_pubkey_der(priv, buf, sizeof(buf));
+    if (len <= 0 ||
+        mbedtls_pk_parse_public_key(pub, buf + sizeof(buf) - len, len) != 0) {
+        mbedtls_pk_free(priv);
+        mbedtls_pk_free(pub);
+        free(priv);
+        free(pub);
         return -1;
     }
     out_priv->alg     = CRYPTO_ALG_RSA4096;
     out_pub->alg      = CRYPTO_ALG_RSA4096;
-    out_priv->key     = pk;
-    out_pub->key      = pk;
-    out_priv->key_len = sizeof(*pk);
-    out_pub->key_len  = sizeof(*pk);
+    out_priv->key     = priv;
+    out_pub->key      = pub;
+    out_priv->key_len = sizeof(*priv);
+    out_pub->key_len  = sizeof(*pub);
     return 0;
 }
 
@@ -53,17 +69,23 @@ int rsa_load_keypair(const char *priv_path, const char *pub_path,
         free(pub_buf);
         return -1;
     }
-    mbedtls_pk_context *pk = calloc(1, sizeof(*pk));
-    if (!pk) {
+    mbedtls_pk_context *priv = calloc(1, sizeof(*priv));
+    mbedtls_pk_context *pub  = calloc(1, sizeof(*pub));
+    if (!priv || !pub) {
+        free(priv);
+        free(pub);
         free(priv_buf);
         free(pub_buf);
         return -1;
     }
-    mbedtls_pk_init(pk);
-    if (mbedtls_pk_parse_key(pk, priv_buf, priv_len, NULL, 0, NULL, NULL) != 0 ||
-        mbedtls_pk_parse_public_key(pk, pub_buf, pub_len) != 0) {
-        mbedtls_pk_free(pk);
-        free(pk);
+    mbedtls_pk_init(priv);
+    mbedtls_pk_init(pub);
+    if (mbedtls_pk_parse_key(priv, priv_buf, priv_len, NULL, 0, NULL, NULL) != 0 ||
+        mbedtls_pk_parse_public_key(pub, pub_buf, pub_len) != 0) {
+        mbedtls_pk_free(priv);
+        mbedtls_pk_free(pub);
+        free(priv);
+        free(pub);
         free(priv_buf);
         free(pub_buf);
         return -1;
@@ -72,10 +94,10 @@ int rsa_load_keypair(const char *priv_path, const char *pub_path,
     free(pub_buf);
     out_priv->alg     = CRYPTO_ALG_RSA4096;
     out_pub->alg      = CRYPTO_ALG_RSA4096;
-    out_priv->key     = pk;
-    out_pub->key      = pk;
-    out_priv->key_len = sizeof(*pk);
-    out_pub->key_len  = sizeof(*pk);
+    out_priv->key     = priv;
+    out_pub->key      = pub;
+    out_priv->key_len = sizeof(*priv);
+    out_pub->key_len  = sizeof(*pub);
     return 0;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -149,7 +149,7 @@ int write_outputs(const char *out_path, int include_keys,
         int ret = 0;
         crypto_key privs[2] = {{0}};
         crypto_key pubs[2] = {{0}};
-        crypto_key priv_ser = {0}, pub_ser = {0};
+        crypto_key priv_blob = {0}, pub_blob = {0};
 
         if (write_component("aes_iv", iv, CRYPTO_AES_IV_SIZE) != 0) {
             goto error;
@@ -177,14 +177,14 @@ int write_outputs(const char *out_path, int include_keys,
                 goto error;
             }
         } else {
-            if (crypto_export_keypair(priv->alg, priv, pub, &priv_ser,
-                                      &pub_ser) != 0) {
+            if (crypto_export_keypair(priv->alg, priv, pub, &priv_blob,
+                                      &pub_blob) != 0) {
                 goto error;
             }
-            if (write_component("sk0", priv_ser.key, priv_ser.key_len) != 0) {
+            if (write_component("sk0", priv_blob.key, priv_blob.key_len) != 0) {
                 goto error;
             }
-            if (write_component("pk0", pub_ser.key, pub_ser.key_len) != 0) {
+            if (write_component("pk0", pub_blob.key, pub_blob.key_len) != 0) {
                 goto error;
             }
         }
@@ -198,8 +198,8 @@ int write_outputs(const char *out_path, int include_keys,
         free(privs[1].key);
         free(pubs[0].key);
         free(pubs[1].key);
-        free(priv_ser.key);
-        free(pub_ser.key);
+        free(priv_blob.key);
+        free(pub_blob.key);
         if (ret != 0) {
             return -1;
         }

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -206,10 +206,7 @@ void test_tool_gen_aes_when_keys_provided(void **state) {
     unlink(sk_path);
     free(priv_blob.key);
     free(pub_blob.key);
-    void *shared = (priv.key == pub.key) ? priv.key : NULL;
     crypto_free_key(&priv);
-    if (shared)
-        pub.key = NULL;
     crypto_free_key(&pub);
 }
 

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -154,15 +154,15 @@ void test_tool_gen_aes_when_keys_provided(void **state) {
     (void)state;
     crypto_key priv = {0}, pub = {0};
     assert_int_equal(crypto_keygen(CRYPTO_ALG_RSA4096, &priv, &pub), 0);
-    crypto_key priv_ser = {0}, pub_ser = {0};
-    assert_int_equal(crypto_export_keypair(CRYPTO_ALG_RSA4096, &priv, &pub, &priv_ser, &pub_ser), 0);
+    crypto_key priv_blob = {0}, pub_blob = {0};
+    assert_int_equal(crypto_export_keypair(CRYPTO_ALG_RSA4096, &priv, &pub, &priv_blob, &pub_blob), 0);
 
     char sk_path[] = "/tmp/skXXXXXX";
     int skfd = mkstemp(sk_path);
     assert_true(skfd != -1);
     FILE *f = fdopen(skfd, "wb");
     assert_non_null(f);
-    assert_int_equal(fwrite(priv_ser.key, 1, priv_ser.key_len, f), priv_ser.key_len);
+    assert_int_equal(fwrite(priv_blob.key, 1, priv_blob.key_len, f), priv_blob.key_len);
     fclose(f);
 
     char pk_path[] = "/tmp/pkXXXXXX";
@@ -170,7 +170,7 @@ void test_tool_gen_aes_when_keys_provided(void **state) {
     assert_true(pkfd != -1);
     f = fdopen(pkfd, "wb");
     assert_non_null(f);
-    assert_int_equal(fwrite(pub_ser.key, 1, pub_ser.key_len, f), pub_ser.key_len);
+    assert_int_equal(fwrite(pub_blob.key, 1, pub_blob.key_len, f), pub_blob.key_len);
     fclose(f);
 
     char in_path[] = "/tmp/inXXXXXX";
@@ -204,8 +204,8 @@ void test_tool_gen_aes_when_keys_provided(void **state) {
     unlink(in_path);
     unlink(pk_path);
     unlink(sk_path);
-    free(priv_ser.key);
-    free(pub_ser.key);
+    free(priv_blob.key);
+    free(pub_blob.key);
     void *shared = (priv.key == pub.key) ? priv.key : NULL;
     crypto_free_key(&priv);
     if (shared)

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -320,7 +320,6 @@ static void test_rsa_lms_sign_verify(void **state) {
                                    msg, sizeof(msg) - 1,
                                    sig, sig_len), 0);
     crypto_free_key(&priv);
-    pub.key = NULL;
     crypto_free_key(&pub);
 }
 
@@ -350,7 +349,6 @@ static void test_rsa_mldsa_sign_verify(void **state) {
                                    msg, sizeof(msg) - 1,
                                    sig, sig_len), 0);
     crypto_free_key(&priv);
-    pub.key = NULL;
     crypto_free_key(&pub);
 }
 
@@ -380,7 +378,6 @@ static void test_lms_mldsa_sign_verify(void **state) {
                                    msg, sizeof(msg) - 1,
                                    sig, sig_len), 0);
     crypto_free_key(&priv);
-    pub.key = NULL;
     crypto_free_key(&pub);
 }
 
@@ -434,8 +431,6 @@ static void test_hybrid_load_keypair(void **state) {
 
     crypto_free_key(&priv);
     crypto_free_key(&priv2);
-    pub.key = NULL;
-    pub2.key = NULL;
     crypto_free_key(&pub);
     crypto_free_key(&pub2);
     for (int i = 0; i < 2; i++) {
@@ -565,14 +560,8 @@ static void outputs_roundtrip(crypto_alg alg) {
         free(priv_parts[i].key);
         free(pub_parts[i].key);
     }
-    if (crypto_is_hybrid_alg(alg)) {
-        crypto_free_key(&priv);
-        pub.key = NULL;
-        crypto_free_key(&pub);
-    } else {
-        crypto_free_key(&priv);
-        crypto_free_key(&pub);
-    }
+    crypto_free_key(&priv);
+    crypto_free_key(&pub);
 }
 
 static void test_rsa_outputs(void **state) {

--- a/tests/test_crypto.c
+++ b/tests/test_crypto.c
@@ -6,6 +6,10 @@
 #include <cmocka.h>
 #include <string.h>
 #include <stdlib.h>
+#include <limits.h>
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 #include <mbedtls/lms.h>
 #include <mbedtls/private_access.h>
@@ -13,6 +17,16 @@
 #include <stdio.h>
 #include <unistd.h>
 #include "api.h"
+
+/* Write key material to a temporary file in place */
+static void write_key_to_temp_file(const crypto_key *key, char path[]) {
+    int fd = mkstemp(path);
+    assert_true(fd != -1);
+    FILE *f = fdopen(fd, "wb");
+    assert_non_null(f);
+    assert_int_equal(fwrite(key->key, 1, key->key_len, f), key->key_len);
+    fclose(f);
+}
 
 /* Compute SHA-384 of 'abc' and compare against known vector */
 static void test_sha384(void **state) {
@@ -238,21 +252,21 @@ static void test_lms_q_next_usable_key(void **state) {
     uint32_t after = pair->priv.MBEDTLS_PRIVATE(q_next_usable_key);
     assert_int_equal(after, before + 1);
 
-    crypto_key priv_ser = {0}, pub_ser = {0};
+    crypto_key priv_blob = {0}, pub_blob = {0};
     assert_int_equal(crypto_export_keypair(CRYPTO_ALG_LMS, &priv, &pub,
-                                          &priv_ser, &pub_ser), 0);
+                                          &priv_blob, &pub_blob), 0);
 
     char path[] = "/tmp/lmsprivXXXXXX";
     int fd = mkstemp(path);
     assert_true(fd != -1);
-    assert_int_equal(write(fd, priv_ser.key, priv_ser.key_len),
-                     (ssize_t)priv_ser.key_len);
+    assert_int_equal(write(fd, priv_blob.key, priv_blob.key_len),
+                     (ssize_t)priv_blob.key_len);
     close(fd);
 
     uint8_t *buf = NULL;
     size_t len = 0;
     assert_int_equal(read_file(path, &buf, &len), 0);
-    assert_int_equal(len, priv_ser.key_len);
+    assert_int_equal(len, priv_blob.key_len);
 
     size_t params_size = sizeof(pair->priv.MBEDTLS_PRIVATE(params));
     uint32_t q_loaded = 0;
@@ -261,8 +275,8 @@ static void test_lms_q_next_usable_key(void **state) {
 
     free(buf);
     unlink(path);
-    free(priv_ser.key);
-    free(pub_ser.key);
+    free(priv_blob.key);
+    free(pub_blob.key);
     crypto_free_key(&priv);
     pub.key = NULL;
     crypto_free_key(&pub);
@@ -378,6 +392,66 @@ static void test_lms_mldsa_sign_verify(void **state) {
     crypto_free_key(&pub);
 }
 
+/* Load a hybrid RSA+ML-DSA key pair from comma-separated files */
+static void test_hybrid_load_keypair(void **state) {
+    (void)state;
+
+    /* Generate a hybrid RSA+ML-DSA key pair and export its components */
+    crypto_key priv = {0}, pub = {0};
+    assert_int_equal(crypto_keygen(CRYPTO_ALG_RSA4096_MLDSA87, &priv, &pub), 0);
+    crypto_key priv_parts[2] = {{0}};
+    crypto_key pub_parts[2] = {{0}};
+    assert_int_equal(crypto_hybrid_export_keypairs(CRYPTO_ALG_RSA4096_MLDSA87,
+                                                  &priv, &pub,
+                                                  priv_parts, pub_parts), 0);
+
+    /* Write each component to a temporary file */
+    char priv0_path[] = "/tmp/priv0XXXXXX";
+    write_key_to_temp_file(&priv_parts[0], priv0_path);
+    char priv1_path[] = "/tmp/priv1XXXXXX";
+    write_key_to_temp_file(&priv_parts[1], priv1_path);
+    char pub0_path[] = "/tmp/pub0XXXXXX";
+    write_key_to_temp_file(&pub_parts[0], pub0_path);
+    char pub1_path[] = "/tmp/pub1XXXXXX";
+    write_key_to_temp_file(&pub_parts[1], pub1_path);
+
+    /* Load the hybrid key pair from comma-separated file paths */
+    char priv_paths[2 * PATH_MAX];
+    char pub_paths[2 * PATH_MAX];
+    snprintf(priv_paths, sizeof(priv_paths), "%s,%s", priv0_path, priv1_path);
+    snprintf(pub_paths, sizeof(pub_paths), "%s,%s", pub0_path, pub1_path);
+    crypto_key priv2 = {0}, pub2 = {0};
+    assert_int_equal(crypto_load_keypair(CRYPTO_ALG_RSA4096_MLDSA87,
+                                         priv_paths, pub_paths,
+                                         &priv2, &pub2), 0);
+
+    /* Ensure a signing roundtrip succeeds with the reloaded keys */
+    const uint8_t msg[] = "roundtrip";
+    uint8_t sig[CRYPTO_MAX_SIG_SIZE];
+    size_t sig_len = sizeof(sig);
+    assert_int_equal(crypto_sign(CRYPTO_ALG_RSA4096_MLDSA87, &priv2,
+                                 msg, sizeof(msg) - 1, sig, &sig_len), 0);
+    assert_int_equal(crypto_verify(CRYPTO_ALG_RSA4096_MLDSA87, &pub2,
+                                   msg, sizeof(msg) - 1, sig, sig_len), 0);
+
+    /* Clean up temporary files and key material */
+    unlink(priv0_path);
+    unlink(priv1_path);
+    unlink(pub0_path);
+    unlink(pub1_path);
+
+    crypto_free_key(&priv);
+    crypto_free_key(&priv2);
+    pub.key = NULL;
+    pub2.key = NULL;
+    crypto_free_key(&pub);
+    crypto_free_key(&pub2);
+    for (int i = 0; i < 2; i++) {
+        free(priv_parts[i].key);
+        free(pub_parts[i].key);
+    }
+}
+
 static void outputs_roundtrip(crypto_alg alg) {
     crypto_key priv = {0}, pub = {0};
     assert_int_equal(crypto_keygen(alg, &priv, &pub), 0);
@@ -420,16 +494,16 @@ static void outputs_roundtrip(crypto_alg alg) {
     free(tmp);
 
     char path[64];
-    crypto_key priv_ser[2] = {{0}};
-    crypto_key pub_ser[2] = {{0}};
+    crypto_key priv_parts[2] = {{0}};
+    crypto_key pub_parts[2] = {{0}};
     size_t key_count = 1;
     if (crypto_is_hybrid_alg(alg)) {
         assert_int_equal(crypto_hybrid_export_keypairs(alg, &priv, &pub,
-                                                      priv_ser, pub_ser), 0);
+                                                      priv_parts, pub_parts), 0);
         key_count = 2;
     } else {
         assert_int_equal(crypto_export_keypair(alg, &priv, &pub,
-                                              &priv_ser[0], &pub_ser[0]), 0);
+                                              &priv_parts[0], &pub_parts[0]), 0);
     }
 
     struct { char name[8]; const uint8_t *data; size_t len; } comps[9];
@@ -444,14 +518,14 @@ static void outputs_roundtrip(crypto_alg alg) {
     comp_idx++;
     for (size_t i = 0; i < key_count; i++) {
         sprintf(comps[comp_idx].name, "sk%zu", i);
-        comps[comp_idx].data = priv_ser[i].key;
-        comps[comp_idx].len  = priv_ser[i].key_len;
+        comps[comp_idx].data = priv_parts[i].key;
+        comps[comp_idx].len  = priv_parts[i].key_len;
         comp_idx++;
     }
     for (size_t i = 0; i < key_count; i++) {
         sprintf(comps[comp_idx].name, "pk%zu", i);
-        comps[comp_idx].data = pub_ser[i].key;
-        comps[comp_idx].len  = pub_ser[i].key_len;
+        comps[comp_idx].data = pub_parts[i].key;
+        comps[comp_idx].len  = pub_parts[i].key_len;
         comp_idx++;
     }
     if (key_count == 2) {
@@ -496,8 +570,8 @@ static void outputs_roundtrip(crypto_alg alg) {
     free(sig);
     free(enc);
     for (size_t i = 0; i < key_count; i++) {
-        free(priv_ser[i].key);
-        free(pub_ser[i].key);
+        free(priv_parts[i].key);
+        free(pub_parts[i].key);
     }
     void *shared = (priv.key == pub.key) ? priv.key : NULL;
     crypto_free_key(&priv);
@@ -680,6 +754,7 @@ const struct CMUnitTest crypto_tests[] = {
     cmocka_unit_test(test_rsa_lms_sign_verify),
     cmocka_unit_test(test_rsa_mldsa_sign_verify),
     cmocka_unit_test(test_lms_mldsa_sign_verify),
+    cmocka_unit_test(test_hybrid_load_keypair),
     cmocka_unit_test(test_rsa_outputs),
     cmocka_unit_test(test_lms_outputs),
     cmocka_unit_test(test_mldsa_outputs),


### PR DESCRIPTION
## Summary
- refactor key loading to use dedicated helpers and fixed-size path buffers
- clarify hybrid key roundtrip test with reusable file-writing helper
- rename serialized key variables for clarity across tests and utilities
- import each algorithm component from comma-separated key files for hybrid algorithms
- document comma-separated key file syntax for CLI usage
- simplify temp key writer and inline template paths in hybrid load test

## Testing
- `scripts/install_third_party.sh`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68be82699c088332bae79ee0def4c247