### PR TITLE
Centralize tool name configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ Follow these steps to build the library and run the unit tests:
    make
    ```
 
-   This produces `libcrypto.a` and the example tool `encsigtool`.
+   This produces `libcrypto.a` and the example command-line tool named according
+   to the `TOOL_NAME` variable.
 
 5. **Run the unit tests**:
 

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -12,6 +12,12 @@
 #include <sys/wait.h>
 #include <limits.h>
 
+#ifndef TOOL_NAME
+#error "TOOL_NAME must be defined"
+#endif
+
+#define TOOL_PATH "./" TOOL_NAME
+
 static void cleanup_tool_outputs(void) {
     const char *paths[] = {
         "sk0.bin", "sk0.hex", "pk0.bin", "pk0.hex",
@@ -130,7 +136,7 @@ void test_tool_gen_keypair_when_aes_provided(void **state) {
     close(ofd);
 
     char cmd[PATH_MAX];
-    snprintf(cmd, sizeof(cmd), "./encsigtool -i %s -o %s --aes-key-path %s --aes-iv %s",
+    snprintf(cmd, sizeof(cmd), TOOL_PATH " -i %s -o %s --aes-key-path %s --aes-iv %s",
              in_path, out_path, key_path, iv_path);
     int ret = system(cmd);
     assert_true(ret != -1);
@@ -187,7 +193,7 @@ void test_tool_gen_aes_when_keys_provided(void **state) {
     close(ofd);
 
     char cmd[PATH_MAX];
-    snprintf(cmd, sizeof(cmd), "./encsigtool -i %s -o %s --pk-path %s --sk-path %s",
+    snprintf(cmd, sizeof(cmd), TOOL_PATH " -i %s -o %s --pk-path %s --sk-path %s",
              in_path, out_path, pk_path, sk_path);
     int ret = system(cmd);
     assert_true(ret != -1);


### PR DESCRIPTION
## Summary
- define TOOL_NAME variable in Makefile to control generated CLI tool name
- use TOOL_NAME macro in tests to reference tool path
- note in AGENTS instructions that TOOL_NAME controls the example CLI name

## Testing
- `scripts/install_third_party.sh`
- `make`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c7c82d10d483328b81b43f9348e15a