### PR TITLE
Refine raw public key export helpers

### DIFF
--- a/include/crypto.h
+++ b/include/crypto.h
@@ -196,6 +196,18 @@ int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
                           crypto_key *out_pub);
 
 /**
+ * crypto_export_raw_pk - export the raw public key bytes for an algorithm
+ * @alg: algorithm identifier
+ * @pub: public key to export
+ * @out_pk: on success, pointer to a newly allocated buffer containing the key
+ * @out_len: on success, length of the exported key buffer
+ *
+ * Return: 0 on success, -1 on error.
+ */
+int crypto_export_raw_pk(crypto_alg alg, const crypto_key *pub,
+                         uint8_t **out_pk, size_t *out_len);
+
+/**
  * crypto_free_key - release any resources held by a key
  * @key: key to free
  */

--- a/include/hybrid_crypto.h
+++ b/include/hybrid_crypto.h
@@ -37,6 +37,18 @@ int hybrid_crypto_export_keypairs(hybrid_alg alg, const crypto_key privs[2],
                                   crypto_key out_privs[2],
                                   crypto_key out_pubs[2]);
 
+/**
+ * hybrid_crypto_export_pk - export raw public keys for a hybrid algorithm
+ * @alg: hybrid algorithm identifier
+ * @pubs: array of two public keys corresponding to @alg
+ * @out_pks: output array of two pointers that will receive allocated buffers
+ * @out_lens: output array of lengths for each public key buffer
+ *
+ * Return: 0 on success, -1 on error.
+ */
+int hybrid_crypto_export_pk(hybrid_alg alg, const crypto_key pubs[2],
+                            uint8_t **out_pks, size_t out_lens[2]);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/lms.h
+++ b/include/lms.h
@@ -67,6 +67,16 @@ int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
                        crypto_key *out_priv, crypto_key *out_pub);
 
 /**
+ * lms_export_raw_pk - export the raw bytes of an LMS public key
+ * @pub: public key to export
+ * @out_pk: on success, pointer to allocated buffer with key bytes
+ * @out_len: on success, length of the exported buffer
+ *
+ * Return: 0 on success, -1 on error.
+ */
+int lms_export_raw_pk(const crypto_key *pub, uint8_t **out_pk, size_t *out_len);
+
+/**
  * lms_free_key - release resources associated with an LMS key
  * @key: key to free
  */

--- a/include/mldsa.h
+++ b/include/mldsa.h
@@ -64,6 +64,16 @@ int mldsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
                          crypto_key *out_priv, crypto_key *out_pub);
 
 /**
+ * mldsa_export_raw_pk - export the raw bytes of an ML-DSA public key
+ * @pub: public key to export
+ * @out_pk: on success, pointer to allocated buffer with key bytes
+ * @out_len: on success, length of the exported buffer
+ *
+ * Return: 0 on success, -1 on error.
+ */
+int mldsa_export_raw_pk(const crypto_key *pub, uint8_t **out_pk, size_t *out_len);
+
+/**
  * mldsa_free_key - release resources for an ML-DSA key
  * @key: key to free
  */

--- a/include/rsa.h
+++ b/include/rsa.h
@@ -67,6 +67,16 @@ int rsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
                        crypto_key *out_priv, crypto_key *out_pub);
 
 /**
+ * rsa_export_raw_pk - export the raw modulus of an RSA public key
+ * @pub: public key to export
+ * @out_pk: on success, pointer to allocated buffer with key bytes
+ * @out_len: on success, length of the exported buffer
+ *
+ * Return: 0 on success, -1 on error.
+ */
+int rsa_export_raw_pk(const crypto_key *pub, uint8_t **out_pk, size_t *out_len);
+
+/**
  * rsa_free_key - release resources associated with an RSA key
  * @key: key to free
  */

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -350,6 +350,22 @@ int crypto_export_keypair(crypto_alg alg, const crypto_key *priv,
     return export_simple(alg, priv, pub, out_priv, out_pub);
 }
 
+int crypto_export_raw_pk(crypto_alg alg, const crypto_key *pub,
+                         uint8_t **out_pk, size_t *out_len)
+{
+    if (!pub || !out_pk || !out_len) {
+        return -1;
+    }
+    if (alg == CRYPTO_ALG_RSA4096) {
+        return rsa_export_raw_pk(pub, out_pk, out_len);
+    } else if (alg == CRYPTO_ALG_LMS) {
+        return lms_export_raw_pk(pub, out_pk, out_len);
+    } else if (alg == CRYPTO_ALG_MLDSA87) {
+        return mldsa_export_raw_pk(pub, out_pk, out_len);
+    }
+    return -1;
+}
+
 void crypto_free_key(crypto_key *key)
 {
     if (!key || !key->key) {

--- a/src/hybrid_crypto.c
+++ b/src/hybrid_crypto.c
@@ -211,4 +211,29 @@ int hybrid_crypto_export_keypairs(hybrid_alg alg, const crypto_key privs[2],
     return 0;
 }
 
+int hybrid_crypto_export_pk(hybrid_alg alg, const crypto_key pubs[2],
+                            uint8_t **out_pks, size_t out_lens[2])
+{
+    if (!pubs || !out_pks || !out_lens) {
+        return -1;
+    }
+    crypto_alg first, second;
+    if (crypto_hybrid_get_algs(alg, &first, &second) != 0) {
+        return -1;
+    }
+    if (pubs[0].alg != first || pubs[1].alg != second) {
+        return -1;
+    }
+    if (crypto_export_raw_pk(first, &pubs[0], &out_pks[0], &out_lens[0]) != 0) {
+        return -1;
+    }
+    if (crypto_export_raw_pk(second, &pubs[1], &out_pks[1], &out_lens[1]) != 0) {
+        free(out_pks[0]);
+        out_pks[0]  = NULL;
+        out_lens[0] = 0;
+        return -1;
+    }
+    return 0;
+}
+
 

--- a/src/lms.c
+++ b/src/lms.c
@@ -225,6 +225,29 @@ int lms_export_keypair(const crypto_key *priv, const crypto_key *pub,
     return 0;
 }
 
+int lms_export_raw_pk(const crypto_key *pub, uint8_t **out_pk, size_t *out_len) {
+    if (!pub || !out_pk || !out_len || pub->alg != CRYPTO_ALG_LMS ||
+        pub->type != CRYPTO_KEY_TYPE_PUBLIC || !pub->key) {
+        return -1;
+    }
+    const mbedtls_lms_public_t *pu = pub->key;
+    size_t pub_len = MBEDTLS_LMS_PUBLIC_KEY_LEN(
+        pu->MBEDTLS_PRIVATE(params).MBEDTLS_PRIVATE(type));
+    uint8_t *buf = malloc(pub_len);
+    if (!buf) {
+        return -1;
+    }
+    size_t olen = 0;
+    if (mbedtls_lms_export_public_key(pu, buf, pub_len, &olen) != 0 ||
+        olen != pub_len) {
+        free(buf);
+        return -1;
+    }
+    *out_pk  = buf;
+    *out_len = pub_len;
+    return 0;
+}
+
 void lms_free_key(crypto_key *key) {
     if (!key || key->alg != CRYPTO_ALG_LMS || !key->key) {
         return;

--- a/src/mldsa.c
+++ b/src/mldsa.c
@@ -111,6 +111,21 @@ int mldsa_export_keypair(const crypto_key *priv, const crypto_key *pub,
     return 0;
 }
 
+int mldsa_export_raw_pk(const crypto_key *pub, uint8_t **out_pk, size_t *out_len) {
+    if (!pub || !out_pk || !out_len || pub->alg != CRYPTO_ALG_MLDSA87 ||
+        pub->type != CRYPTO_KEY_TYPE_PUBLIC || !pub->key) {
+        return -1;
+    }
+    uint8_t *buf = malloc(pub->key_len);
+    if (!buf) {
+        return -1;
+    }
+    memcpy(buf, pub->key, pub->key_len);
+    *out_pk  = buf;
+    *out_len = pub->key_len;
+    return 0;
+}
+
 void mldsa_free_key(crypto_key *key) {
     if (!key || key->alg != CRYPTO_ALG_MLDSA87 || !key->key) {
         return;


### PR DESCRIPTION
## Summary
- inline the algorithm dispatch directly inside `crypto_export_raw_pk` instead of relying on an extra helper
- keep `hybrid_crypto_export_pk` available for hybrid schemes while reusing the primitive exporters
- trim the redundant RSA, LMS, and ML-DSA raw export unit tests while retaining hybrid coverage

## Testing
- make test *(fails: missing `cmocka.h` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddf17d95648332bdf55f62c7dfbfd3